### PR TITLE
Define psycopg2 adapters for numpy types

### DIFF
--- a/mm_cataloguer/index_netcdf.py
+++ b/mm_cataloguer/index_netcdf.py
@@ -67,7 +67,10 @@ from nchelpers import CFDataset
 from nchelpers.date_utils import to_datetime
 from modelmeta import Model, Run, Emission, DataFile, TimeSet, Time, ClimatologicalTime, DataFileVariable, \
     VariableAlias, LevelSet, Level, Grid, YCellBound, EnsembleDataFileVariables
+from mm_cataloguer import psycopg2_adapters
 
+
+# Set up logging
 
 formatter = logging.Formatter('%(asctime)s %(levelname)s: %(message)s', "%Y-%m-%d %H:%M:%S")
 handler = logging.StreamHandler()
@@ -77,6 +80,10 @@ logger = logging.getLogger(__name__)
 logger.addHandler(handler)
 logger.setLevel(logging.DEBUG)
 
+# Register psycopg adapters for numpy types
+psycopg2_adapters.register()
+
+# Miscellaneous constants
 
 filepath_converter = 'realpath'
 
@@ -901,7 +908,7 @@ def is_regular_series(values, relative_tolerance=1e-6):
     """Return True iff the given series of values is regular, i.e., has equal steps between values,
     within a relative tolerance."""
     diffs = np.diff(values)
-    return bool(abs(np.max(diffs) / np.min(diffs) - 1) < relative_tolerance)
+    return abs(np.max(diffs) / np.min(diffs) - 1) < relative_tolerance
 
 
 def mean_step_size(values):

--- a/mm_cataloguer/index_netcdf.py
+++ b/mm_cataloguer/index_netcdf.py
@@ -698,7 +698,7 @@ def find_grid(sesh, cf, var_name):
         if value == 0.0:
             return attribute == 0.0
         else:
-            return func.abs((attribute - value) / attribute < relative_tolerance)
+            return func.abs((attribute - value) / attribute) < relative_tolerance
 
     info = get_grid_info(cf, var_name)
     

--- a/mm_cataloguer/index_netcdf.py
+++ b/mm_cataloguer/index_netcdf.py
@@ -901,7 +901,7 @@ def is_regular_series(values, relative_tolerance=1e-6):
     """Return True iff the given series of values is regular, i.e., has equal steps between values,
     within a relative tolerance."""
     diffs = np.diff(values)
-    return abs(np.max(diffs) / np.min(diffs) - 1) < relative_tolerance
+    return bool(abs(np.max(diffs) / np.min(diffs) - 1) < relative_tolerance)
 
 
 def mean_step_size(values):

--- a/mm_cataloguer/index_netcdf.py
+++ b/mm_cataloguer/index_netcdf.py
@@ -901,7 +901,7 @@ def is_regular_series(values, relative_tolerance=1e-6):
     """Return True iff the given series of values is regular, i.e., has equal steps between values,
     within a relative tolerance."""
     diffs = np.diff(values)
-    return abs((np.max(diffs) / np.min(diffs) - 1) < relative_tolerance)
+    return abs(np.max(diffs) / np.min(diffs) - 1) < relative_tolerance
 
 
 def mean_step_size(values):

--- a/mm_cataloguer/psycopg2_adapters.py
+++ b/mm_cataloguer/psycopg2_adapters.py
@@ -1,0 +1,28 @@
+import numpy
+from psycopg2.extensions import register_adapter, AsIs
+
+def register():
+    """Register adapters for numpy types."""
+
+    # Simple umeric types need only be converted by ``AsIs``
+    for numpy_type in (
+        numpy.int_,
+        numpy.intc,
+        numpy.intp,
+        numpy.int8,
+        numpy.int16,
+        numpy.int32,
+        numpy.int64,
+        numpy.uint8,
+        numpy.uint16,
+        numpy.uint32,
+        numpy.uint64,
+        numpy.float_,
+        numpy.float16,
+        numpy.float32,
+        numpy.float64,
+    ):
+        register_adapter(numpy_type, AsIs)
+
+    # Booleans have to be converted
+    register_adapter(numpy.bool_, lambda v: AsIs(bool(v)))


### PR DESCRIPTION
This first manifested as a failure in a Boolean type (compounded by an error in the expression for that boolean), but it turns out that `psycopg2` does not know how to convert any `numpy` types to SQL expressions, and we have to define adapters for that. Turns out to be easy.

Resolves #23 