### PR TITLE
Associate ensemble by regex or perfect match to DataFile.filename

### DIFF
--- a/mm_cataloguer/associate_ensemble.py
+++ b/mm_cataloguer/associate_ensemble.py
@@ -240,7 +240,12 @@ if __name__ == '__main__':
     )
     args = parser.parse_args()
 
+    if args.var_names:
+        var_names = args.var_names.split(',')
+    else:
+        var_names = None
+
     main(
         args.dsn, args.ensemble_name, args.ensemble_ver,
-        args.regex_filepaths, args.filepaths, args.var_names.split(',')
+        args.regex_filepaths, args.filepaths, var_names
     )

--- a/mm_cataloguer/associate_ensemble.py
+++ b/mm_cataloguer/associate_ensemble.py
@@ -240,7 +240,7 @@ if __name__ == '__main__':
     )
     args = parser.parse_args()
 
-    associate_ensemble_to_filepaths(
+    main(
         args.dsn, args.ensemble_name, args.ensemble_ver,
         args.regex_filepaths, args.filepaths, args.var_names.split(',')
     )


### PR DESCRIPTION
Resolves #36 

This is a nearly complete rewrite of `associate_ensemble`: 

- The previous version opened the NetCDF file (!) and used a `index_netcdf` function to find the matching `DataFile` record. That was slooooow (and dummmmb).
- This version only uses the database. It matches against `DataFile.filename` using an equality or regex match, according to flag. Testing is better too.