### PR TITLE
Indexer: Set Grid.srid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
   postgresql: "9.3"
 install:
   - pip install -i https://pypi.pacificclimate.org/simple -r requirements.txt
+  - pip install -r test_requirements.txt
   - pip install .
 # command to run tests
 script: py.test -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ python:
   - 3.6
 addons:
   postgresql: "9.3"
+  apt:
+      packages:
+        - postgresql-9.3-postgis-2.3
 install:
   - pip install -i https://pypi.pacificclimate.org/simple -r requirements.txt
   - pip install -r test_requirements.txt

--- a/mm_cataloguer/index_netcdf.py
+++ b/mm_cataloguer/index_netcdf.py
@@ -579,6 +579,19 @@ def insert_spatial_ref_sys(sesh, cf, var_name):
 
     sesh.add(spatial_ref_sys)
 
+    # At this point, ``spatial_ref_sys.id`` is still in the form of a SELECT
+    # statement, which causes an error if it is attempted to be used in the
+    # Python code. So instead we flush  the session to the database(not commit!
+    # the current transaction can still be rolled back), then query to get the
+    # SRS back with all values (i.e., ``id`` and ``auth_id``) fully defined.
+    # Documentation seems to indicate that ``Session.refresh()`` should do this
+    # for us (and more elegantly), but experimentation shows it doesn't.
+    sesh.flush()
+    # The newly inserted SRS is by definition the one with the highest id.
+    spatial_ref_sys = (sesh.query(SpatialRefSys)
+                       .order_by(SpatialRefSys.id.desc())
+                       .first())
+
     return spatial_ref_sys
 
 

--- a/mm_cataloguer/index_netcdf.py
+++ b/mm_cataloguer/index_netcdf.py
@@ -522,8 +522,7 @@ def find_spatial_ref_sys(sesh, cf, var_name):
         .filter(SpatialRefSys.srtext ==
                 wkt(cf.proj4_string(var_name, default=default_proj4)))
     )
-    return q.first()
-    # return q.one_or_none()
+    return q.one_or_none()
 
 
 def insert_spatial_ref_sys(sesh, cf, var_name):

--- a/mm_cataloguer/index_netcdf.py
+++ b/mm_cataloguer/index_netcdf.py
@@ -522,7 +522,7 @@ def find_spatial_ref_sys(sesh, cf, var_name):
         .filter(SpatialRefSys.srtext ==
                 wkt(cf.proj4_string(var_name, default=default_proj4)))
     )
-    return q.first()
+    return q.one_or_none()
 
 
 def insert_spatial_ref_sys(sesh, cf, var_name):

--- a/mm_cataloguer/index_netcdf.py
+++ b/mm_cataloguer/index_netcdf.py
@@ -105,8 +105,6 @@ psycopg2_adapters.register()
 # Miscellaneous constants
 
 filepath_converter = 'realpath'
-default_proj4_string = '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs'
-
 
 
 # Decorators

--- a/mm_cataloguer/index_netcdf.py
+++ b/mm_cataloguer/index_netcdf.py
@@ -524,6 +524,7 @@ def find_grid(sesh, cf, var_name):
             .filter(Grid.xc_count == len(info['xc_values']))
             .filter(Grid.yc_count == len(info['yc_values']))
             .filter(Grid.evenly_spaced_y == info['evenly_spaced_y'])
+            # TODO: filter on spatial ref sys (key srid)
             .first()
             )
 
@@ -572,6 +573,7 @@ def insert_grid(sesh, cf, var_name):
         cell_avg_area_sq_km=cell_avg_area_sq_km(),
         xc_units=info['xc_var'].units,
         yc_units=info['yc_var'].units,
+        srid=cf.proj4_string(var_name)
     )
     sesh.add(grid)
 

--- a/modelmeta/v2.py
+++ b/modelmeta/v2.py
@@ -5,8 +5,7 @@ __all__ = ['ClimatologicalTime', 'DataFile', 'DataFileVariable',
            'DataFileVariablesQcFlag', 'Emission', 'Ensemble', 'EnsembleDataFileVariables',
            'Grid', 'Level', 'LevelSet', 'Model', 'QcFlag', 'Run',
            'Time', 'TimeSet', 'Variable', 'VariableAlias', 'YCellBound',
-           'SpatialRefSys',
-           'test_dsn', 'test_session']
+           'SpatialRefSys']
 
 from pkg_resources import resource_filename
 
@@ -414,16 +413,3 @@ class SpatialRefSys(Base):
 
 # We don't declare constraints on SpatialRefSys because the Postgis plugin is
 # responsible for creating it.
-
-
-# TODO: Move this out to conftest. How did this even get here?
-
-test_dsn = 'sqlite+pysqlite:///{0}'.format(resource_filename('modelmeta', 'data/mddb-v2.sqlite'))
-
-def test_session():
-    '''This creates a testing database session that can be used as a test fixture.
-    '''
-    from sqlalchemy import create_engine
-    engine = create_engine(test_dsn)
-    Session = sessionmaker(bind=engine)
-    return Session()

--- a/modelmeta/v2.py
+++ b/modelmeta/v2.py
@@ -5,6 +5,7 @@ __all__ = ['ClimatologicalTime', 'DataFile', 'DataFileVariable',
            'DataFileVariablesQcFlag', 'Emission', 'Ensemble', 'EnsembleDataFileVariables',
            'Grid', 'Level', 'LevelSet', 'Model', 'QcFlag', 'Run',
            'Time', 'TimeSet', 'Variable', 'VariableAlias', 'YCellBound',
+           'SpatialRefSys',
            'test_dsn', 'test_session']
 
 from pkg_resources import resource_filename
@@ -15,6 +16,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.orderinglist import ordering_list
 from sqlalchemy.orm import relationship, backref, sessionmaker
 
+print('### Creating modelmeta ORM')
 Base = declarative_base()
 metadata = Base.metadata
 
@@ -392,6 +394,29 @@ class YCellBound(Base):
 
 Index('y_c_b_grid_id_key', YCellBound.grid_id, unique=False)
 
+
+class SpatialRefSys(Base):
+    """This table is established by the Postgis plugin."""
+    __tablename__ = 'spatial_ref_sys'
+
+    #column definitions
+    id = Column('srid', Integer, primary_key=True, nullable=False)
+    auth_name = Column(String(length=256))
+    auth_srid = Column(Integer)
+    srtext = Column(String(length=2048))
+    proj4text = Column(String(length=2048))
+
+    def __repr__(self):
+        return '{}({}, {}, {}, {})'.format(
+            self.__class__.__name__, self.id,
+            self.auth_name, self.auth_srid, self.srtext, self.proj4text
+        )
+
+# We don't declare constraints on SpatialRefSys because the Postgis plugin is
+# responsible for creating it.
+
+
+# TODO: Move this out to conftest. How did this even get here?
 
 test_dsn = 'sqlite+pysqlite:///{0}'.format(resource_filename('modelmeta', 'data/mddb-v2.sqlite'))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ netCDF4
 nchelpers>=5.3.0
 python-dateutil
 sqlparse
-PyCRS
+git+git://github.com/karimbahgat/PyCRS.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ netCDF4
 nchelpers>=5.3.0
 python-dateutil
 sqlparse
+PyCRS

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ netCDF4
 nchelpers>=5.3.0
 python-dateutil
 sqlparse
-git+git://github.com/karimbahgat/PyCRS.git
+git+git://github.com/karimbahgat/PyCRS.git@70e4210b16260b2c17fd31947816836a29a12117

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ netCDF4
 nchelpers>=5.1.2
 python-dateutil
 sqlparse
-testing.postgresql

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ alembic
 psycopg2
 numpy
 netCDF4
-nchelpers>=5.1.2
+nchelpers>=5.3.0
 python-dateutil
 sqlparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ alembic
 psycopg2
 numpy
 netCDF4
-nchelpers>=5.3.0
+nchelpers>=5.3.0,<6
 python-dateutil
 sqlparse
 git+git://github.com/karimbahgat/PyCRS.git@70e4210b16260b2c17fd31947816836a29a12117

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         psycopg2
         numpy
         netCDF4
-        nchelpers>=5.2.0
+        nchelpers>=5.3.0
         python-dateutil
         sqlparse
     '''.split(),

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         nchelpers>=5.3.0
         python-dateutil
         sqlparse
+        PyCRS
     '''.split(),
     package_data = {
         'modelmeta': '''

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,2 @@
+pytest
+testing.postgresql

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,7 +142,7 @@ def test_session_with_ensembles(
     yield test_session_with_empty_db
 
 
-# Dataset fixtures
+# Parametrized fixtures
 
 # We parametrize this fixture so that every test that uses it is run for all
 # params. This can be overridden on specific tests by using
@@ -168,3 +168,8 @@ def tiny_dataset(request):
     """
     filename = 'data/tiny_{}.nc'.format(request.param)
     return CFDataset(resource_filename('modelmeta', filename))
+
+
+@pytest.fixture(params=[False, True])
+def insert(request):
+    return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,6 +93,27 @@ def test_session_factory(test_engine):
     yield Session
 
 
+# Function-scoped test session based on SESSION-scoped database, engine, and
+# session factory fixtures.
+# These sessions are fast to create, and achieve test isolation by rolling back
+# their actions on teardown.
+
+@pytest.fixture(scope='function')
+def test_session_with_empty_db(test_session_factory):
+    session = test_session_factory()
+    yield session
+    session.rollback()
+    session.close()
+
+
+@pytest.fixture(scope='function')
+def test_session_with_ensembles(
+        test_session_with_empty_db, ensemble1, ensemble2
+):
+    test_session_with_empty_db.add_all([ensemble1, ensemble2])
+    yield test_session_with_empty_db
+
+
 # Function-scoped databases
 # Use these databases when testing functions that take a database or session 
 # factory argument rather than a session. Because these databases are scoped 
@@ -121,25 +142,16 @@ def test_session_factory_fs(test_engine_fs):
     yield Session
 
 
-# Function-scoped test session based on session-scoped database, engine, and
+# Function-scoped test session based on FUNCTION-scoped database, engine, and
 # session factory fixtures.
-# These sessions are fast to create, and achieve test isolation by rolling back
-# their actions on teardown.
+# These sessions are SLOW to create, and achieve test isolation using a new
+# database each time.
 
 @pytest.fixture(scope='function')
-def test_session_with_empty_db(test_session_factory):
-    session = test_session_factory()
+def test_session_with_empty_db_fs(test_session_factory_fs):
+    session = test_session_factory_fs()
     yield session
-    session.rollback()
     session.close()
-
-
-@pytest.fixture(scope='function')
-def test_session_with_ensembles(
-        test_session_with_empty_db, ensemble1, ensemble2
-):
-    test_session_with_empty_db.add_all([ensemble1, ensemble2])
-    yield test_session_with_empty_db
 
 
 # Parametrized fixtures

--- a/tests/mm_cataloguer/test_index.py
+++ b/tests/mm_cataloguer/test_index.py
@@ -226,7 +226,6 @@ def test_insert_model(test_session_with_empty_db, tiny_dataset):
     )
 
 
-@pytest.mark.parametrize('insert', [False, True])
 def test_find_model(test_session_with_empty_db, tiny_dataset, insert):
     check_find(
         find_model,
@@ -237,7 +236,6 @@ def test_find_model(test_session_with_empty_db, tiny_dataset, insert):
     )
 
 
-@pytest.mark.parametrize('insert', [False, True])
 def test_find_or_insert_model(test_session_with_empty_db, tiny_dataset, insert):
     check_find_or_insert(
         find_or_insert_model,
@@ -262,7 +260,6 @@ def test_insert_emission(test_session_with_empty_db, tiny_dataset):
     )
 
 
-@pytest.mark.parametrize('insert', [False, True])
 def test_find_emission(test_session_with_empty_db, tiny_dataset, insert):
     check_find(
         find_emission,
@@ -273,7 +270,6 @@ def test_find_emission(test_session_with_empty_db, tiny_dataset, insert):
     )
 
 
-@pytest.mark.parametrize('insert', [False, True])
 def test_find_or_insert_emission(
         test_session_with_empty_db, tiny_dataset, insert):
     check_find_or_insert(
@@ -319,7 +315,6 @@ def test_insert_run(test_session_with_empty_db, tiny_dataset):
     )
 
 
-@pytest.mark.parametrize('insert', [False, True])
 def test_find_run(test_session_with_empty_db, tiny_dataset, insert):
     check_find(
         find_run,
@@ -330,7 +325,6 @@ def test_find_run(test_session_with_empty_db, tiny_dataset, insert):
     )
 
 
-@pytest.mark.parametrize('insert', [False, True])
 def test_find_or_insert_run(test_session_with_empty_db, tiny_dataset, insert):
     check_find_or_insert(
         find_or_insert_run,
@@ -360,7 +354,6 @@ def test_insert_variable_alias(test_session_with_empty_db, tiny_dataset):
     )
 
 
-@pytest.mark.parametrize('insert', [False, True])
 def test_find_variable_alias(test_session_with_empty_db, tiny_dataset, insert):
     check_find(
         find_variable_alias,
@@ -372,7 +365,6 @@ def test_find_variable_alias(test_session_with_empty_db, tiny_dataset, insert):
     )
 
 
-@pytest.mark.parametrize('insert', [False, True])
 def test_find_or_insert_variable_alias(
         test_session_with_empty_db, tiny_dataset, insert):
     check_find_or_insert(
@@ -424,7 +416,6 @@ def test_insert_level_set(
         )
 
 
-@pytest.mark.parametrize('insert', [False, True])
 @pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_dataset'])
 def test_find_level_set(
         test_session_with_empty_db, tiny_dataset, var_name,
@@ -439,7 +430,6 @@ def test_find_level_set(
     )
 
 
-@pytest.mark.parametrize('insert', [False, True])
 @pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_dataset'])
 def test_find_or_insert_level_set(
         test_session_with_empty_db, tiny_dataset, var_name,
@@ -477,7 +467,6 @@ def test_insert_spatial_ref_sys(test_session_with_empty_db, tiny_dataset):
            test_session_with_empty_db.query(func.max(SpatialRefSys.id)).scalar()
 
 
-@pytest.mark.parametrize('insert', [False, True])
 def test_find_spatial_ref_sys(test_session_with_empty_db, tiny_dataset, insert):
     check_find(
         find_spatial_ref_sys,
@@ -489,7 +478,6 @@ def test_find_spatial_ref_sys(test_session_with_empty_db, tiny_dataset, insert):
     )
 
 
-@pytest.mark.parametrize('insert', [False, True])
 def test_find_or_insert_spatial_ref_sys(
         test_session_with_empty_db, tiny_dataset, insert):
     check_find_or_insert(
@@ -547,7 +535,6 @@ def test_insert_grid(test_session_with_empty_db, tiny_dataset):
         assert len(grid.y_cell_bounds) == len(info['yc_var'][:])
 
 
-@pytest.mark.parametrize('insert', [False, True])
 def test_find_grid(test_session_with_empty_db, tiny_dataset, insert):
     check_find(
         find_grid,
@@ -559,7 +546,6 @@ def test_find_grid(test_session_with_empty_db, tiny_dataset, insert):
     )
 
 
-@pytest.mark.parametrize('insert', [False, True])
 def test_find_or_insert_grid(test_session_with_empty_db, tiny_dataset, insert):
     check_find_or_insert(
         find_or_insert_grid,
@@ -622,7 +608,6 @@ def test_insert_data_file_variable(test_session_with_empty_db, tiny_dataset):
         test_session_with_empty_db, tiny_dataset, var_name)
 
 
-@pytest.mark.parametrize('insert', [False, True])
 def test_find_data_file_variable(
         test_session_with_empty_db, tiny_dataset, insert
 ):
@@ -639,7 +624,6 @@ def test_find_data_file_variable(
     )
 
 
-@pytest.mark.parametrize('insert', [False, True])
 def test_find_or_insert_data_file_variable(
         test_session_with_empty_db, tiny_dataset, insert):
     var_name = tiny_dataset.dependent_varnames()[0]
@@ -704,7 +688,6 @@ def test_insert_timeset(test_session_with_empty_db, tiny_dataset):
             to_datetime(tiny_dataset.time_range_as_dates)
 
 
-@pytest.mark.parametrize('insert', [False, True])
 def test_find_timeset(test_session_with_empty_db, tiny_dataset, insert):
     check_find(
         find_timeset,
@@ -715,7 +698,6 @@ def test_find_timeset(test_session_with_empty_db, tiny_dataset, insert):
     )
 
 
-@pytest.mark.parametrize('insert', [False, True])
 def test_find_or_insert_timeset(
         test_session_with_empty_db, tiny_dataset, insert
 ):
@@ -756,7 +738,6 @@ def test_insert_data_file(
         find_timeset(test_session_with_empty_db, tiny_dataset)
 
 
-@pytest.mark.parametrize('insert', [False, True])
 def test_find_data_file(test_session_with_empty_db, tiny_dataset, insert):
     data_file = cond_insert_data_file(
         test_session_with_empty_db, tiny_dataset, invoke=insert)

--- a/tests/mm_cataloguer/test_index.py
+++ b/tests/mm_cataloguer/test_index.py
@@ -155,505 +155,505 @@ level_set_parametrization = ('tiny_dataset, var_name, level_axis_var_name', [
 ])
 
 
-# # Test schema setup
-#
-# def print_query_results(session, query, title=None):
-#     print()
-#     if title:
-#         print(title)
-#         print('-' * len(title))
-#     result = session.execute(query)
-#     for row in result:
-#         print(row)
-#
-#
-# def test_schemas(test_session_with_empty_db):
-#     print_query_results(test_session_with_empty_db, '''
-#         SHOW search_path
-#     ''', title='search_path')
-#     print_query_results(test_session_with_empty_db, '''
-#         select nspname
-#         from pg_catalog.pg_namespace
-#     ''', title='Schemas')
-#     print_query_results(test_session_with_empty_db, '''
-#         select *
-#         from information_schema.tables
-#         where table_schema not in ('pg_catalog', 'information_schema')
-#     ''', title='Tables')
-#
-#
-# def test_spatial_ref_sys_orm(test_session_with_empty_db):
-#     q = test_session_with_empty_db.query(SpatialRefSys).limit(10)
-#     for r in q.all():
-#         print(r.id, r.proj4text)
-#
-#
-# # Test helper functions
-#
-# def test_get_grid_info(tiny_dataset):
-#     info = get_grid_info(tiny_dataset, tiny_dataset.dependent_varnames()[0])
-#     assert set(info.keys()) == \
-#         set('xc_var yc_var xc_values yc_values '
-#             'xc_grid_step yc_grid_step evenly_spaced_y'.split())
-#     assert info['xc_var'] == tiny_dataset.variables['lon']
-#     assert info['yc_var'] == tiny_dataset.variables['lat']
-#
-#
-# # Note: Overriding default parametrization of tiny_dataset in these tests.
-# @pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_dataset'])
-# def test_get_level_set_info(tiny_dataset, var_name, level_axis_var_name):
-#     info = get_level_set_info(tiny_dataset, var_name)
-#     if level_axis_var_name:
-#         assert set(info.keys()) == \
-#             set('level_axis_var vertical_levels'.split())
-#         assert info['level_axis_var'] == \
-#             tiny_dataset.variables[level_axis_var_name]
-#     else:
-#         assert info is None
-#
-#
-# # Model
-#
-# cond_insert_model = conditional(insert_model)
-#
-#
-# def test_insert_model(test_session_with_empty_db, tiny_dataset):
-#     check_insert(
-#         insert_model, test_session_with_empty_db, tiny_dataset,
-#         short_name=tiny_dataset.metadata.model,
-#         organization=tiny_dataset.metadata.institution,
-#         type=tiny_dataset.model_type,
-#     )
-#
-#
-# @pytest.mark.parametrize('insert', [False, True])
-# def test_find_model(test_session_with_empty_db, tiny_dataset, insert):
-#     check_find(
-#         find_model,
-#         cond_insert_model,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         invoke=insert
-#     )
-#
-#
-# @pytest.mark.parametrize('insert', [False, True])
-# def test_find_or_insert_model(test_session_with_empty_db, tiny_dataset, insert):
-#     check_find_or_insert(
-#         find_or_insert_model,
-#         cond_insert_model,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         invoke=insert
-#     )
-#
-#
-# # Emission
-#
-# cond_insert_emission = conditional(insert_emission)
-#
-#
-# def test_insert_emission(test_session_with_empty_db, tiny_dataset):
-#     check_insert(
-#         insert_emission,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         short_name=tiny_dataset.metadata.emissions
-#     )
-#
-#
-# @pytest.mark.parametrize('insert', [False, True])
-# def test_find_emission(test_session_with_empty_db, tiny_dataset, insert):
-#     check_find(
-#         find_emission,
-#         cond_insert_emission,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         invoke=insert
-#     )
-#
-#
-# @pytest.mark.parametrize('insert', [False, True])
-# def test_find_or_insert_emission(
-#         test_session_with_empty_db, tiny_dataset, insert):
-#     check_find_or_insert(
-#         find_or_insert_emission,
-#         cond_insert_emission,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         invoke=insert
-#     )
-#
-#
-# # Run
-#
-# def insert_run_plus(test_session_with_empty_db, tiny_dataset):
-#     """Insert a run plus associated emission and model objects.
-#     Return run, model, and emission inserted.
-#     """
-#     emission = insert_emission(test_session_with_empty_db, tiny_dataset)
-#     model = insert_model(test_session_with_empty_db, tiny_dataset)
-#     run = insert_run(test_session_with_empty_db, tiny_dataset, model, emission)
-#     return run, model, emission
-#
-#
-# def insert_run_plus_prime(*args):
-#     """Same as above, but just return the run."""
-#     return insert_run_plus(*args)[0]
-#
-#
-# cond_insert_run_plus = conditional(insert_run_plus,
-#                                    false_value=(None, None, None))
-# cond_insert_run_plus_prime = conditional(insert_run_plus_prime)
-#
-#
-# def test_insert_run(test_session_with_empty_db, tiny_dataset):
-#     run, model, emission = \
-#         insert_run_plus(test_session_with_empty_db, tiny_dataset)
-#     check_properties(
-#         run,
-#         name=tiny_dataset.metadata.run,
-#         project=tiny_dataset.metadata.project,
-#         model=model,
-#         emission=emission,
-#     )
-#
-#
-# @pytest.mark.parametrize('insert', [False, True])
-# def test_find_run(test_session_with_empty_db, tiny_dataset, insert):
-#     check_find(
-#         find_run,
-#         cond_insert_run_plus_prime,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         invoke=insert
-#     )
-#
-#
-# @pytest.mark.parametrize('insert', [False, True])
-# def test_find_or_insert_run(test_session_with_empty_db, tiny_dataset, insert):
-#     check_find_or_insert(
-#         find_or_insert_run,
-#         cond_insert_run_plus_prime,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         invoke=insert
-#     )
-#
-#
-# # VariableAlias
-#
-# cond_insert_variable_alias = conditional(insert_variable_alias)
-#
-#
-# def test_insert_variable_alias(test_session_with_empty_db, tiny_dataset):
-#     var_name = tiny_dataset.dependent_varnames()[0]
-#     variable = tiny_dataset.variables[var_name]
-#     check_insert(
-#         insert_variable_alias,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         var_name,
-#         long_name=variable.long_name,
-#         standard_name=usable_name(variable),
-#         units=variable.units,
-#     )
-#
-#
-# @pytest.mark.parametrize('insert', [False, True])
-# def test_find_variable_alias(test_session_with_empty_db, tiny_dataset, insert):
-#     check_find(
-#         find_variable_alias,
-#         cond_insert_variable_alias,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         tiny_dataset.dependent_varnames()[0],
-#         invoke=insert
-#     )
-#
-#
-# @pytest.mark.parametrize('insert', [False, True])
-# def test_find_or_insert_variable_alias(
-#         test_session_with_empty_db, tiny_dataset, insert):
-#     check_find_or_insert(
-#         find_or_insert_variable_alias,
-#         cond_insert_variable_alias,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         tiny_dataset.dependent_varnames()[0],
-#         invoke=insert
-#     )
-#
-#
-# # LevelSet, Level
-#
-# cond_insert_level_set = conditional(insert_level_set)
-#
-#
-# # Note: Overriding default parametrization of tiny_dataset in these tests.
-#
-# @pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_dataset'])
-# def test_insert_level_set(
-#         test_session_with_empty_db, tiny_dataset,
-#         var_name, level_axis_var_name
-# ):
-#     variable = tiny_dataset.variables[var_name]
-#     if level_axis_var_name:
-#         level_axis_var = tiny_dataset.variables[level_axis_var_name]
-#         assert level_axis_var_name in variable.dimensions
-#         level_set = check_insert(
-#             insert_level_set,
-#             test_session_with_empty_db,
-#             tiny_dataset, var_name,
-#             level_units=level_axis_var.units
-#         )
-#         levels = (
-#             test_session_with_empty_db.query(Level)
-#             .filter(Level.level_set == level_set)
-#             .all()
-#         )
-#         assert level_set.levels == levels
-#         assert list(level.vertical_level for level in levels) == \
-#             list(vertical_level for vertical_level in level_axis_var[:])
-#     else:
-#         check_insert(
-#             insert_level_set,
-#             test_session_with_empty_db,
-#             tiny_dataset,
-#             var_name
-#         )
-#
-#
-# @pytest.mark.parametrize('insert', [False, True])
-# @pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_dataset'])
-# def test_find_level_set(
-#         test_session_with_empty_db, tiny_dataset, var_name,
-#         level_axis_var_name, insert):
-#     check_find(
-#         find_level_set,
-#         cond_insert_level_set,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         var_name,
-#         invoke=insert
-#     )
-#
-#
-# @pytest.mark.parametrize('insert', [False, True])
-# @pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_dataset'])
-# def test_find_or_insert_level_set(
-#         test_session_with_empty_db, tiny_dataset, var_name,
-#         level_axis_var_name, insert):
-#     check_find_or_insert(
-#         find_or_insert_level_set,
-#         cond_insert_level_set,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         var_name,
-#         invoke=insert,
-#         expect_insert=bool(level_axis_var_name)
-#     )
-#
-#
-# # SpatialRefSys
-#
-# cond_insert_spatial_ref_sys = conditional(insert_spatial_ref_sys)
-#
-#
-# def test_insert_spatial_ref_sys(test_session_with_empty_db, tiny_dataset):
-#     var_name = tiny_dataset.dependent_varnames()[0]
-#     proj4_string = '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs'
-#     srs = check_insert(
-#         insert_spatial_ref_sys,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         var_name,
-#         auth_name='PCIC',
-#         proj4text=proj4_string,
-#         srtext=wkt(proj4_string),
-#     )
-#     assert srs.id > 990000
-#     assert srs.id == \
-#            test_session_with_empty_db.query(func.max(SpatialRefSys.id)).scalar()
-#
-#
-# @pytest.mark.parametrize('insert', [False, True])
-# def test_find_spatial_ref_sys(test_session_with_empty_db, tiny_dataset, insert):
-#     check_find(
-#         find_spatial_ref_sys,
-#         cond_insert_spatial_ref_sys,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         tiny_dataset.dependent_varnames()[0],
-#         invoke=insert
-#     )
-#
-#
-# @pytest.mark.parametrize('insert', [False, True])
-# def test_find_or_insert_spatial_ref_sys(
-#         test_session_with_empty_db, tiny_dataset, insert):
-#     check_find_or_insert(
-#         find_or_insert_spatial_ref_sys,
-#         cond_insert_spatial_ref_sys,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         tiny_dataset.dependent_varnames()[0],
-#         invoke=insert
-#     )
-#
-#
-# # Grid, YCellBound
-#
-# def insert_grid_plus(sesh, cf, var_name):
-#     """Insert a grid plus associated spatial ref sys object.
-#     Return grid and spatial ref sys inserted.
-#     """
-#     srs = insert_spatial_ref_sys(sesh, cf, var_name)
-#     grid = insert_grid(sesh, cf, var_name, srs)
-#     return grid, srs
-#
-#
-# def insert_grid_plus_prime(*args):
-#     """Same as above, but just return the grid."""
-#     return insert_grid_plus(*args)[0]
-#
-#
-# cond_insert_grid_plus = conditional(insert_grid_plus,
-#                                    false_value=(None, None))
-# cond_insert_grid_plus_prime = conditional(insert_grid_plus_prime)
-#
-#
-# def test_insert_grid(test_session_with_empty_db, tiny_dataset):
-#     var_name = tiny_dataset.dependent_varnames()[0]
-#     info = get_grid_info(tiny_dataset, var_name)
-#     grid, srs = insert_grid_plus(
-#         test_session_with_empty_db, tiny_dataset, var_name)
-#     check_properties(
-#         grid,
-#         xc_origin=info['xc_values'][0],
-#         yc_origin=info['yc_values'][0],
-#         xc_grid_step=info['xc_grid_step'],
-#         yc_grid_step=info['yc_grid_step'],
-#         xc_count=len(info['xc_values']),
-#         yc_count=len(info['yc_values']),
-#         evenly_spaced_y=info['evenly_spaced_y'],
-#         xc_units=info['xc_var'].units,
-#         yc_units=info['yc_var'].units,
-#     )
-#     assert grid.srid == srs.id
-#     if grid.evenly_spaced_y:
-#         assert len(grid.y_cell_bounds) == 0
-#     else:
-#         assert len(grid.y_cell_bounds) == len(info['yc_var'][:])
-#
-#
-# @pytest.mark.parametrize('insert', [False, True])
-# def test_find_grid(test_session_with_empty_db, tiny_dataset, insert):
-#     check_find(
-#         find_grid,
-#         cond_insert_grid_plus_prime,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         tiny_dataset.dependent_varnames()[0],
-#         invoke=insert
-#     )
-#
-#
-# @pytest.mark.parametrize('insert', [False, True])
-# def test_find_or_insert_grid(test_session_with_empty_db, tiny_dataset, insert):
-#     check_find_or_insert(
-#         find_or_insert_grid,
-#         cond_insert_grid_plus_prime,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         tiny_dataset.dependent_varnames()[0],
-#         invoke=insert
-#     )
-#
-#
-# # DataFileVariable
-#
-# def insert_data_file_variable_plus(
-#         test_session_with_empty_db, tiny_dataset, var_name, data_file):
-#     """Insert a ``DataFileVariable`` plus associated ``VariableAlias``,
-#     ``LevelSet``, and ``Grid`` objects.
-#     Return ``DataFileVariable`` inserted.
-#     """
-#     variable_alias = insert_variable_alias(
-#         test_session_with_empty_db, tiny_dataset, var_name)
-#     level_set = insert_level_set(
-#         test_session_with_empty_db, tiny_dataset, var_name)
-#     grid = insert_grid_plus_prime(
-#         test_session_with_empty_db, tiny_dataset, var_name)
-#     data_file_variable = insert_data_file_variable(
-#         test_session_with_empty_db, tiny_dataset, var_name,
-#         data_file, variable_alias, level_set, grid
-#     )
-#     return data_file_variable
-#
-#
-# cond_insert_data_file_variable_plus = \
-#     conditional(insert_data_file_variable_plus)
-#
-#
-# def test_insert_data_file_variable(test_session_with_empty_db, tiny_dataset):
-#     var_name = tiny_dataset.dependent_varnames()[0]
-#     variable = tiny_dataset.variables[var_name]
-#     range_min, range_max = tiny_dataset.var_range(var_name)
-#     data_file = insert_data_file(test_session_with_empty_db, tiny_dataset)
-#     dfv = check_insert(
-#         insert_data_file_variable_plus,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         var_name,
-#         data_file,
-#         file=data_file,
-#         netcdf_variable_name=var_name,
-#         variable_cell_methods=variable.cell_methods,
-#         range_min=range_min,
-#         range_max=range_max,
-#         disabled=False,
-#     )
-#     assert dfv.variable_alias == find_variable_alias(
-#         test_session_with_empty_db, tiny_dataset, var_name)
-#     assert dfv.level_set == find_level_set(
-#         test_session_with_empty_db, tiny_dataset, var_name)
-#     assert dfv.grid == find_grid(
-#         test_session_with_empty_db, tiny_dataset, var_name)
-#
-#
-# @pytest.mark.parametrize('insert', [False, True])
-# def test_find_data_file_variable(
-#         test_session_with_empty_db, tiny_dataset, insert
-# ):
-#     var_name = tiny_dataset.dependent_varnames()[0]
-#     data_file = insert_data_file(test_session_with_empty_db, tiny_dataset)
-#     check_find(
-#         find_data_file_variable,
-#         cond_insert_data_file_variable_plus,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         var_name,
-#         data_file,
-#         invoke=insert
-#     )
-#
-#
-# @pytest.mark.parametrize('insert', [False, True])
-# def test_find_or_insert_data_file_variable(
-#         test_session_with_empty_db, tiny_dataset, insert):
-#     var_name = tiny_dataset.dependent_varnames()[0]
-#     data_file = insert_data_file(test_session_with_empty_db, tiny_dataset)
-#     check_find_or_insert(
-#         find_or_insert_data_file_variable,
-#         cond_insert_data_file_variable_plus,
-#         test_session_with_empty_db,
-#         tiny_dataset,
-#         var_name,
-#         data_file,
-#         invoke=insert
-#     )
-#
+# Test schema setup
+
+def print_query_results(session, query, title=None):
+    print()
+    if title:
+        print(title)
+        print('-' * len(title))
+    result = session.execute(query)
+    for row in result:
+        print(row)
+
+
+def test_schemas(test_session_with_empty_db):
+    print_query_results(test_session_with_empty_db, '''
+        SHOW search_path
+    ''', title='search_path')
+    print_query_results(test_session_with_empty_db, '''
+        select nspname
+        from pg_catalog.pg_namespace
+    ''', title='Schemas')
+    print_query_results(test_session_with_empty_db, '''
+        select *
+        from information_schema.tables
+        where table_schema not in ('pg_catalog', 'information_schema')
+    ''', title='Tables')
+
+
+def test_spatial_ref_sys_orm(test_session_with_empty_db):
+    q = test_session_with_empty_db.query(SpatialRefSys).limit(10)
+    for r in q.all():
+        print(r.id, r.proj4text)
+
+
+# Test helper functions
+
+def test_get_grid_info(tiny_dataset):
+    info = get_grid_info(tiny_dataset, tiny_dataset.dependent_varnames()[0])
+    assert set(info.keys()) == \
+        set('xc_var yc_var xc_values yc_values '
+            'xc_grid_step yc_grid_step evenly_spaced_y'.split())
+    assert info['xc_var'] == tiny_dataset.variables['lon']
+    assert info['yc_var'] == tiny_dataset.variables['lat']
+
+
+# Note: Overriding default parametrization of tiny_dataset in these tests.
+@pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_dataset'])
+def test_get_level_set_info(tiny_dataset, var_name, level_axis_var_name):
+    info = get_level_set_info(tiny_dataset, var_name)
+    if level_axis_var_name:
+        assert set(info.keys()) == \
+            set('level_axis_var vertical_levels'.split())
+        assert info['level_axis_var'] == \
+            tiny_dataset.variables[level_axis_var_name]
+    else:
+        assert info is None
+
+
+# Model
+
+cond_insert_model = conditional(insert_model)
+
+
+def test_insert_model(test_session_with_empty_db, tiny_dataset):
+    check_insert(
+        insert_model, test_session_with_empty_db, tiny_dataset,
+        short_name=tiny_dataset.metadata.model,
+        organization=tiny_dataset.metadata.institution,
+        type=tiny_dataset.model_type,
+    )
+
+
+@pytest.mark.parametrize('insert', [False, True])
+def test_find_model(test_session_with_empty_db, tiny_dataset, insert):
+    check_find(
+        find_model,
+        cond_insert_model,
+        test_session_with_empty_db,
+        tiny_dataset,
+        invoke=insert
+    )
+
+
+@pytest.mark.parametrize('insert', [False, True])
+def test_find_or_insert_model(test_session_with_empty_db, tiny_dataset, insert):
+    check_find_or_insert(
+        find_or_insert_model,
+        cond_insert_model,
+        test_session_with_empty_db,
+        tiny_dataset,
+        invoke=insert
+    )
+
+
+# Emission
+
+cond_insert_emission = conditional(insert_emission)
+
+
+def test_insert_emission(test_session_with_empty_db, tiny_dataset):
+    check_insert(
+        insert_emission,
+        test_session_with_empty_db,
+        tiny_dataset,
+        short_name=tiny_dataset.metadata.emissions
+    )
+
+
+@pytest.mark.parametrize('insert', [False, True])
+def test_find_emission(test_session_with_empty_db, tiny_dataset, insert):
+    check_find(
+        find_emission,
+        cond_insert_emission,
+        test_session_with_empty_db,
+        tiny_dataset,
+        invoke=insert
+    )
+
+
+@pytest.mark.parametrize('insert', [False, True])
+def test_find_or_insert_emission(
+        test_session_with_empty_db, tiny_dataset, insert):
+    check_find_or_insert(
+        find_or_insert_emission,
+        cond_insert_emission,
+        test_session_with_empty_db,
+        tiny_dataset,
+        invoke=insert
+    )
+
+
+# Run
+
+def insert_run_plus(test_session_with_empty_db, tiny_dataset):
+    """Insert a run plus associated emission and model objects.
+    Return run, model, and emission inserted.
+    """
+    emission = insert_emission(test_session_with_empty_db, tiny_dataset)
+    model = insert_model(test_session_with_empty_db, tiny_dataset)
+    run = insert_run(test_session_with_empty_db, tiny_dataset, model, emission)
+    return run, model, emission
+
+
+def insert_run_plus_prime(*args):
+    """Same as above, but just return the run."""
+    return insert_run_plus(*args)[0]
+
+
+cond_insert_run_plus = conditional(insert_run_plus,
+                                   false_value=(None, None, None))
+cond_insert_run_plus_prime = conditional(insert_run_plus_prime)
+
+
+def test_insert_run(test_session_with_empty_db, tiny_dataset):
+    run, model, emission = \
+        insert_run_plus(test_session_with_empty_db, tiny_dataset)
+    check_properties(
+        run,
+        name=tiny_dataset.metadata.run,
+        project=tiny_dataset.metadata.project,
+        model=model,
+        emission=emission,
+    )
+
+
+@pytest.mark.parametrize('insert', [False, True])
+def test_find_run(test_session_with_empty_db, tiny_dataset, insert):
+    check_find(
+        find_run,
+        cond_insert_run_plus_prime,
+        test_session_with_empty_db,
+        tiny_dataset,
+        invoke=insert
+    )
+
+
+@pytest.mark.parametrize('insert', [False, True])
+def test_find_or_insert_run(test_session_with_empty_db, tiny_dataset, insert):
+    check_find_or_insert(
+        find_or_insert_run,
+        cond_insert_run_plus_prime,
+        test_session_with_empty_db,
+        tiny_dataset,
+        invoke=insert
+    )
+
+
+# VariableAlias
+
+cond_insert_variable_alias = conditional(insert_variable_alias)
+
+
+def test_insert_variable_alias(test_session_with_empty_db, tiny_dataset):
+    var_name = tiny_dataset.dependent_varnames()[0]
+    variable = tiny_dataset.variables[var_name]
+    check_insert(
+        insert_variable_alias,
+        test_session_with_empty_db,
+        tiny_dataset,
+        var_name,
+        long_name=variable.long_name,
+        standard_name=usable_name(variable),
+        units=variable.units,
+    )
+
+
+@pytest.mark.parametrize('insert', [False, True])
+def test_find_variable_alias(test_session_with_empty_db, tiny_dataset, insert):
+    check_find(
+        find_variable_alias,
+        cond_insert_variable_alias,
+        test_session_with_empty_db,
+        tiny_dataset,
+        tiny_dataset.dependent_varnames()[0],
+        invoke=insert
+    )
+
+
+@pytest.mark.parametrize('insert', [False, True])
+def test_find_or_insert_variable_alias(
+        test_session_with_empty_db, tiny_dataset, insert):
+    check_find_or_insert(
+        find_or_insert_variable_alias,
+        cond_insert_variable_alias,
+        test_session_with_empty_db,
+        tiny_dataset,
+        tiny_dataset.dependent_varnames()[0],
+        invoke=insert
+    )
+
+
+# LevelSet, Level
+
+cond_insert_level_set = conditional(insert_level_set)
+
+
+# Note: Overriding default parametrization of tiny_dataset in these tests.
+
+@pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_dataset'])
+def test_insert_level_set(
+        test_session_with_empty_db, tiny_dataset,
+        var_name, level_axis_var_name
+):
+    variable = tiny_dataset.variables[var_name]
+    if level_axis_var_name:
+        level_axis_var = tiny_dataset.variables[level_axis_var_name]
+        assert level_axis_var_name in variable.dimensions
+        level_set = check_insert(
+            insert_level_set,
+            test_session_with_empty_db,
+            tiny_dataset, var_name,
+            level_units=level_axis_var.units
+        )
+        levels = (
+            test_session_with_empty_db.query(Level)
+            .filter(Level.level_set == level_set)
+            .all()
+        )
+        assert level_set.levels == levels
+        assert list(level.vertical_level for level in levels) == \
+            list(vertical_level for vertical_level in level_axis_var[:])
+    else:
+        check_insert(
+            insert_level_set,
+            test_session_with_empty_db,
+            tiny_dataset,
+            var_name
+        )
+
+
+@pytest.mark.parametrize('insert', [False, True])
+@pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_dataset'])
+def test_find_level_set(
+        test_session_with_empty_db, tiny_dataset, var_name,
+        level_axis_var_name, insert):
+    check_find(
+        find_level_set,
+        cond_insert_level_set,
+        test_session_with_empty_db,
+        tiny_dataset,
+        var_name,
+        invoke=insert
+    )
+
+
+@pytest.mark.parametrize('insert', [False, True])
+@pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_dataset'])
+def test_find_or_insert_level_set(
+        test_session_with_empty_db, tiny_dataset, var_name,
+        level_axis_var_name, insert):
+    check_find_or_insert(
+        find_or_insert_level_set,
+        cond_insert_level_set,
+        test_session_with_empty_db,
+        tiny_dataset,
+        var_name,
+        invoke=insert,
+        expect_insert=bool(level_axis_var_name)
+    )
+
+
+# SpatialRefSys
+
+cond_insert_spatial_ref_sys = conditional(insert_spatial_ref_sys)
+
+
+def test_insert_spatial_ref_sys(test_session_with_empty_db, tiny_dataset):
+    var_name = tiny_dataset.dependent_varnames()[0]
+    proj4_string = '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs'
+    srs = check_insert(
+        insert_spatial_ref_sys,
+        test_session_with_empty_db,
+        tiny_dataset,
+        var_name,
+        auth_name='PCIC',
+        proj4text=proj4_string,
+        srtext=wkt(proj4_string),
+    )
+    assert srs.id > 990000
+    assert srs.id == \
+           test_session_with_empty_db.query(func.max(SpatialRefSys.id)).scalar()
+
+
+@pytest.mark.parametrize('insert', [False, True])
+def test_find_spatial_ref_sys(test_session_with_empty_db, tiny_dataset, insert):
+    check_find(
+        find_spatial_ref_sys,
+        cond_insert_spatial_ref_sys,
+        test_session_with_empty_db,
+        tiny_dataset,
+        tiny_dataset.dependent_varnames()[0],
+        invoke=insert
+    )
+
+
+@pytest.mark.parametrize('insert', [False, True])
+def test_find_or_insert_spatial_ref_sys(
+        test_session_with_empty_db, tiny_dataset, insert):
+    check_find_or_insert(
+        find_or_insert_spatial_ref_sys,
+        cond_insert_spatial_ref_sys,
+        test_session_with_empty_db,
+        tiny_dataset,
+        tiny_dataset.dependent_varnames()[0],
+        invoke=insert
+    )
+
+
+# Grid, YCellBound
+
+def insert_grid_plus(sesh, cf, var_name):
+    """Insert a grid plus associated spatial ref sys object.
+    Return grid and spatial ref sys inserted.
+    """
+    srs = insert_spatial_ref_sys(sesh, cf, var_name)
+    grid = insert_grid(sesh, cf, var_name, srs)
+    return grid, srs
+
+
+def insert_grid_plus_prime(*args):
+    """Same as above, but just return the grid."""
+    return insert_grid_plus(*args)[0]
+
+
+cond_insert_grid_plus = conditional(insert_grid_plus,
+                                   false_value=(None, None))
+cond_insert_grid_plus_prime = conditional(insert_grid_plus_prime)
+
+
+def test_insert_grid(test_session_with_empty_db, tiny_dataset):
+    var_name = tiny_dataset.dependent_varnames()[0]
+    info = get_grid_info(tiny_dataset, var_name)
+    grid, srs = insert_grid_plus(
+        test_session_with_empty_db, tiny_dataset, var_name)
+    check_properties(
+        grid,
+        xc_origin=info['xc_values'][0],
+        yc_origin=info['yc_values'][0],
+        xc_grid_step=info['xc_grid_step'],
+        yc_grid_step=info['yc_grid_step'],
+        xc_count=len(info['xc_values']),
+        yc_count=len(info['yc_values']),
+        evenly_spaced_y=info['evenly_spaced_y'],
+        xc_units=info['xc_var'].units,
+        yc_units=info['yc_var'].units,
+    )
+    assert grid.srid == srs.id
+    if grid.evenly_spaced_y:
+        assert len(grid.y_cell_bounds) == 0
+    else:
+        assert len(grid.y_cell_bounds) == len(info['yc_var'][:])
+
+
+@pytest.mark.parametrize('insert', [False, True])
+def test_find_grid(test_session_with_empty_db, tiny_dataset, insert):
+    check_find(
+        find_grid,
+        cond_insert_grid_plus_prime,
+        test_session_with_empty_db,
+        tiny_dataset,
+        tiny_dataset.dependent_varnames()[0],
+        invoke=insert
+    )
+
+
+@pytest.mark.parametrize('insert', [False, True])
+def test_find_or_insert_grid(test_session_with_empty_db, tiny_dataset, insert):
+    check_find_or_insert(
+        find_or_insert_grid,
+        cond_insert_grid_plus_prime,
+        test_session_with_empty_db,
+        tiny_dataset,
+        tiny_dataset.dependent_varnames()[0],
+        invoke=insert
+    )
+
+
+# DataFileVariable
+
+def insert_data_file_variable_plus(
+        test_session_with_empty_db, tiny_dataset, var_name, data_file):
+    """Insert a ``DataFileVariable`` plus associated ``VariableAlias``,
+    ``LevelSet``, and ``Grid`` objects.
+    Return ``DataFileVariable`` inserted.
+    """
+    variable_alias = insert_variable_alias(
+        test_session_with_empty_db, tiny_dataset, var_name)
+    level_set = insert_level_set(
+        test_session_with_empty_db, tiny_dataset, var_name)
+    grid = insert_grid_plus_prime(
+        test_session_with_empty_db, tiny_dataset, var_name)
+    data_file_variable = insert_data_file_variable(
+        test_session_with_empty_db, tiny_dataset, var_name,
+        data_file, variable_alias, level_set, grid
+    )
+    return data_file_variable
+
+
+cond_insert_data_file_variable_plus = \
+    conditional(insert_data_file_variable_plus)
+
+
+def test_insert_data_file_variable(test_session_with_empty_db, tiny_dataset):
+    var_name = tiny_dataset.dependent_varnames()[0]
+    variable = tiny_dataset.variables[var_name]
+    range_min, range_max = tiny_dataset.var_range(var_name)
+    data_file = insert_data_file(test_session_with_empty_db, tiny_dataset)
+    dfv = check_insert(
+        insert_data_file_variable_plus,
+        test_session_with_empty_db,
+        tiny_dataset,
+        var_name,
+        data_file,
+        file=data_file,
+        netcdf_variable_name=var_name,
+        variable_cell_methods=variable.cell_methods,
+        range_min=range_min,
+        range_max=range_max,
+        disabled=False,
+    )
+    assert dfv.variable_alias == find_variable_alias(
+        test_session_with_empty_db, tiny_dataset, var_name)
+    assert dfv.level_set == find_level_set(
+        test_session_with_empty_db, tiny_dataset, var_name)
+    assert dfv.grid == find_grid(
+        test_session_with_empty_db, tiny_dataset, var_name)
+
+
+@pytest.mark.parametrize('insert', [False, True])
+def test_find_data_file_variable(
+        test_session_with_empty_db, tiny_dataset, insert
+):
+    var_name = tiny_dataset.dependent_varnames()[0]
+    data_file = insert_data_file(test_session_with_empty_db, tiny_dataset)
+    check_find(
+        find_data_file_variable,
+        cond_insert_data_file_variable_plus,
+        test_session_with_empty_db,
+        tiny_dataset,
+        var_name,
+        data_file,
+        invoke=insert
+    )
+
+
+@pytest.mark.parametrize('insert', [False, True])
+def test_find_or_insert_data_file_variable(
+        test_session_with_empty_db, tiny_dataset, insert):
+    var_name = tiny_dataset.dependent_varnames()[0]
+    data_file = insert_data_file(test_session_with_empty_db, tiny_dataset)
+    check_find_or_insert(
+        find_or_insert_data_file_variable,
+        cond_insert_data_file_variable_plus,
+        test_session_with_empty_db,
+        tiny_dataset,
+        var_name,
+        data_file,
+        invoke=insert
+    )
+
 
 # Timeset
 


### PR DESCRIPTION
Resolves https://github.com/pacificclimate/modelmeta/issues/53

Now sets `Grid.srid`, which previously was left null, by finding or inserting an entry in the table `spatial_ref_sys` (ORM: `SpatialRefSys`) that describes the coordinate reference system defined in the metadata of the indexed file for the variable for which a `Grid` is being inserted. If no such metadata exists, a default entry corresponding to a PROJ.4 string of `+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs` is used.

Notes: 

- This PR updates the ORM to model the table `spatial_ref_sys`. This table is created in schema `public` by PostGIS, and the other (modelmeta) tables are created in the username schema (e.g., `pcic_meta`). The ORM does not define the schema explicitly because it is different in each modelmeta database. Correctly setting `search_path` in each database ensures that tables are findable. In the test framework, all tables are in schema `public`.

- This PR adds a dependency on the PyCRS package, which has a fixed bug that affects us. The only way to get the fix is to install the package directly from the github repo, which seems possibly fragile.