### PR TITLE
Allow index_netcdf to reference relative paths

### DIFF
--- a/mm_cataloguer/index_netcdf.py
+++ b/mm_cataloguer/index_netcdf.py
@@ -1191,6 +1191,7 @@ def index_netcdf_file(filename, Session):
     """
     session = Session()
     data_file_id = None
+    filename = os.path.abspath(filename)
     try:
         with CFDataset(filename) as cf:
             data_file = find_update_or_insert_cf_file(session, cf)


### PR DESCRIPTION
A common use case for indexing a set of files is to cd into the local
directory containing the files and then to run "index_netcdf *". This
will fail, unfortunately, because the database tracks absolute paths
and ``index_netcdf`` naively accepts the paths from the command line.

This PR tells ``index_netcdf`` to use the normalized absolutized version of
each path, so that the command line args will match up with the paths
in the database.