### PR TITLE
Index discrete sampling geometry datasets

### DIFF
--- a/mm_cataloguer/index_netcdf.py
+++ b/mm_cataloguer/index_netcdf.py
@@ -878,13 +878,10 @@ def find_or_insert_stations(sesh, cf, var_name):
     :param var_name: (str) name of variable
     :return: (list of Station) stations at which this variable is defined
     """
-    variable = cf.variables[var_name]
-    # TODO: Move some of this to nchelpers
-    coordinates = [cf.variables[name] for name in variable.coordinates.split()]
-    instance_dim = cf.dimensions[coordinates[0].dimensions[0]]
-    name = next(c for c in coordinates if getattr(c, 'cf_role', None) == 'timeseries_id')
-    lat = next(c for c in coordinates if c.name in ['lat', 'latitude'])
-    lon = next(c for c in coordinates if c.name in ['lon', 'longitude'])
+    instance_dim = cf.instance_dim(var_name)
+    name = cf.id_instance_var(var_name)
+    lat = cf.spatial_instance_var(var_name, 'X')
+    lon = cf.spatial_instance_var(var_name, 'Y')
     return [
         find_or_insert_station(sesh, cf, i, name, lon, lat)
         for i in range(0, instance_dim.size)

--- a/mm_cataloguer/index_netcdf.py
+++ b/mm_cataloguer/index_netcdf.py
@@ -87,6 +87,9 @@ from modelmeta import \
     DataFileVariable, VariableAlias, EnsembleDataFileVariables, \
     DataFileVariableGridded, \
     LevelSet, Level, Grid, YCellBound, \
+    DataFileVariableDSGTimeSeries, \
+    Station, \
+    DataFileVariableDSGTimeSeriesXStation, \
     SpatialRefSys
 from mm_cataloguer import psycopg2_adapters
 
@@ -755,22 +758,22 @@ def find_data_file_variable(sesh, cf, var_name, data_file):
     :param data_file: (DataFile) data file to associate this dfv to
     :return: existing ``DataFileVariableGridded`` record or None
     """
-    q = (sesh.query(DataFileVariableGridded)
+    DataFileVariableSubtype = {
+        'gridded': DataFileVariableGridded,
+        'dsg.timeSeries': DataFileVariableDSGTimeSeries,
+    }[cf.sampling_geometry]
+
+    q = (sesh.query(DataFileVariableSubtype)
          .filter(DataFileVariableGridded.file == data_file)
          .filter(DataFileVariableGridded.netcdf_variable_name == var_name)
          )
     return q.first()
 
 
-def insert_data_file_variable(
+def insert_data_file_variable_gridded(
         sesh, cf, var_name, data_file, variable_alias, level_set, grid):
     """Insert a new ``DataFileVariableGridded`` record corresponding to a named
     variable in a NetCDF file and associated to a specified ``DataFile`` record.
-
-    NOTE: Parameter `cf` is not used in this function, but it is retained to
-    maintain a consistent signature amongst all `find_` functions. This is
-    useful in testing, although its absence could be accommodated with more
-    complex testing code.
 
     :param sesh: modelmeta database session
     :param cf: CFDatafile object representing NetCDF file
@@ -782,23 +785,136 @@ def insert_data_file_variable(
     :param grid: (Grid) grid to associate to this dfv
     :return: inserted DataFileVariableGridded record
     """
+    assert cf.sampling_geometry == 'gridded'
     variable = cf.variables[var_name]
     range_min, range_max = cf.var_range(var_name)
     dfv = DataFileVariableGridded(
         file=data_file,
         variable_alias=variable_alias,
-        # TODO: verify no value for this and other unspecified attributes
-        # derivation_method=,
-        variable_cell_methods=variable.cell_methods,
-        level_set=level_set,
-        grid=grid,
+        disabled=False,
         netcdf_variable_name=var_name,
         range_min=range_min,
         range_max=range_max,
-        disabled=False,
+        variable_cell_methods=variable.cell_methods,
+        # TODO: verify no value for this and other unspecified attributes
+        # derivation_method=,
+        level_set=level_set,
+        grid=grid,
     )
     sesh.add(dfv)
     return dfv
+
+
+def insert_data_file_variable_dsg_time_series(
+        sesh, cf, var_name, data_file, variable_alias):
+    """Insert a new ``DataFileVariableDSGTimeSeries`` record corresponding to
+    a named variable in a NetCDF file and associated to a specified
+    ``DataFile`` record.
+
+    :param sesh: modelmeta database session
+    :param cf: CFDatafile object representing NetCDF file
+    :param var_name: (str) name of variable
+    :param data_file: (DataFile) data file to associate this dfv to
+    :param variable_alias: (VariableAlias) variable alias to associate to
+        this dfv
+    :return: inserted DataFileVariableGridded record
+    """
+    assert cf.sampling_geometry == 'dsg.timeSeries'
+    variable = cf.variables[var_name]
+    range_min, range_max = cf.var_range(var_name)
+    dfv = DataFileVariableDSGTimeSeries(
+        file=data_file,
+        variable_alias=variable_alias,
+        disabled=False,
+        netcdf_variable_name=var_name,
+        range_min=range_min,
+        range_max=range_max,
+        variable_cell_methods=variable.cell_methods,
+    )
+    sesh.add(dfv)
+    return dfv
+
+
+def find_station(sesh, cf, i, name, x, y):
+    return (
+        sesh.query(Station)
+        .filter_by(
+            name=name[i],
+            x=x[i],
+            x_units=x.units,
+            y=y[i],
+            y_units=y.units,
+        )
+        .first()
+    )
+
+
+def insert_station(sesh, cf, i, name, x, y):
+    station = Station(
+        name=name[i],
+        x=x[i],
+        x_units=x.units,
+        y=y[i],
+        y_units=y.units,
+    )
+    sesh.add(station)
+    return station
+
+
+def find_or_insert_station(sesh, cf, i, name, x, y):
+    station = find_station(sesh, cf, i, name, x, y)
+    if station:
+        return station
+    return insert_station(sesh, cf, i, name, x, y)
+
+
+def find_or_insert_stations(sesh, cf, var_name):
+    """
+    Find or insert all ``Station`` records for the stations at which a named
+    variable is defined in a NetCDF file.
+
+    :param sesh: modelmeta database session
+    :param cf: CFDatafile object representing NetCDF file
+    :param var_name: (str) name of variable
+    :return: (list of Station) stations at which this variable is defined
+    """
+    variable = cf.variables[var_name]
+    # Some of this probably belongs in nchelpers
+    coordinates = [cf.variables[name] for name in variable.coordinates.split()]
+    instance_dim = cf.dimensions[coordinates[0].dimensions[0]]
+    name = next(c for c in coordinates if c.cf_role == 'timeseries_id')
+    lat = next(c for c in coordinates if c.name in ['lat', 'latitude'])
+    lon = next(c for c in coordinates if c.name in ['lon', 'longitude'])
+
+    return [
+        find_or_insert_station(cf, var_name, i, name, lon, lat)
+        for i in range(0, instance_dim.size)
+    ]
+
+
+def associate_stations_to_data_file_variable_dsg_time_series(
+        sesh, cf, var_name, data_file_variable_dsg_ts):
+    """
+    Associate Station records for all stations defined for to the named variable
+    to the given ``DataFileVariableDSGTimeSeries``.
+
+    :param sesh: modelmeta database session
+    :param cf: CFDatafile object representing NetCDF file
+    :param var_name: (str) name of variable
+    :param data_file_variable_dsg_ts: (DataFileVariableDSGTimeSeries)
+        data file variable to associate
+    :return: (list of DataFileVariableDSGTimeSeriesXStation) association records
+    """
+    stations = find_or_insert_stations(sesh, cf, var_name)
+    associations = [
+        DataFileVariableDSGTimeSeriesXStation(
+            data_file_variable_dsg_ts=data_file_variable_dsg_ts,
+            station=station,
+        )
+        for station in stations
+    ]
+    sesh.add_all(associations)
+    return associations
 
 
 def find_or_insert_data_file_variable(sesh, cf, var_name, data_file):
@@ -820,13 +936,26 @@ def find_or_insert_data_file_variable(sesh, cf, var_name, data_file):
     dfv = find_data_file_variable(sesh, cf, var_name, data_file)
     if dfv:
         return dfv
+
+    # Common to all sampling geometry types
     variable_alias = find_or_insert_variable_alias(sesh, cf, var_name)
     assert variable_alias
-    level_set = find_or_insert_level_set(sesh, cf, var_name)
-    grid = find_or_insert_grid(sesh, cf, var_name)
-    assert grid
-    return insert_data_file_variable(
-        sesh, cf, var_name, data_file, variable_alias, level_set, grid)
+
+    if cf.sampling_geometry == 'gridded':
+        level_set = find_or_insert_level_set(sesh, cf, var_name)
+        grid = find_or_insert_grid(sesh, cf, var_name)
+        assert grid
+        return insert_data_file_variable_gridded(
+            sesh, cf, var_name, data_file, variable_alias, level_set, grid)
+    else:
+        dfv = insert_data_file_variable_dsg_time_series(
+            sesh, cf, var_name, data_file, variable_alias)
+        # The following is an instance of the rule that there are only two
+        # difficult things in CS: naming things and cache invalidation.
+        associate_stations_to_data_file_variable_dsg_time_series(
+            sesh, cf, var_name, dfv)
+        return dfv
+
 
 
 def find_or_insert_data_file_variables(sesh, cf, data_file):
@@ -972,6 +1101,9 @@ def insert_data_file(sesh, cf):  # create.data.file.id
     assert timeset
     run = find_or_insert_run(sesh, cf)
     assert run
+
+    # TODO: DSG: Only assign dim_names for gridded datasets
+    # TODO: DSG: Need CFDataset.geometry_type
     dim_names = cf.axes_dim()
 
     df = DataFile(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ SQLAlchemy
 alembic
 psycopg2
 numpy
-netCDF4
-nchelpers>=5.4.0,<6
+netCDF4==1.3
+nchelpers>=5.5.0,<6
 python-dateutil
 sqlparse
 git+git://github.com/karimbahgat/PyCRS.git@70e4210b16260b2c17fd31947816836a29a12117

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ alembic
 psycopg2
 numpy
 netCDF4
-nchelpers>=5.3.0,<6
+nchelpers>=5.4.0,<6
 python-dateutil
 sqlparse
 git+git://github.com/karimbahgat/PyCRS.git@70e4210b16260b2c17fd31947816836a29a12117

--- a/scripts/nc-copy-modify.py
+++ b/scripts/nc-copy-modify.py
@@ -1,4 +1,12 @@
 #! python
+
+"""
+Slice a NetCDF file along the time dimension.
+"""
+
+# TODO: Generalize to slice along any combination of dimensions.
+# Change args to source dest dim_name:index_range*
+# Don't specify variables, slice em all.
 from argparse import ArgumentParser
 
 from netCDF4 import Dataset

--- a/scripts/nc-copy-modify.py
+++ b/scripts/nc-copy-modify.py
@@ -1,0 +1,96 @@
+#! python
+from argparse import ArgumentParser
+
+from netCDF4 import Dataset
+
+
+def nc_copy(source_fp, dest_fp, time_dimension, time_indices, variables):
+    print('nc_copy({source_fp}, {dest_fp}, {time_dimension}, {time_indices}, {variables})'.format(**locals()))
+
+    with Dataset(source_fp) as source:
+        with Dataset(dest_fp, mode='w') as dest:
+
+            # Copy global attributes
+            for name in source.ncattrs():
+                dest.setncattr(name, source.getncattr(name))
+
+            # Create and copy dimensions
+            for name, dimension in source.dimensions.items():
+                if time_indices and name == time_dimension:
+                    size = time_indices[1] - time_indices[0] + 1
+                else:
+                    size = dimension.size
+                print('Copying dimension {} ({})'.format(name, size))
+                dest.createDimension(name, size=size)
+
+            # Create and copy variables
+            for name, source_variable in source.variables.items():
+                # Create variable
+                contiguous = False
+                chunksizes = None
+                # if source_variable.chunking() == 'contiguous':
+                #     contiguous = True
+                #     chunksizes = None
+                # else:
+                #     contiguous = False
+                #     chunksizes = source_variable.chunking()
+                #     print('chunksizes={}'.format(chunksizes))
+
+                print('Copying variable {}'.format(name))
+                dest_variable = dest.createVariable(
+                    name, source_variable.datatype,
+                    dimensions=source_variable.dimensions,
+                    **source_variable.filters(),
+                    endian=source_variable.endian(),
+                    contiguous=contiguous,
+                    chunksizes=chunksizes,
+                )
+
+                # Copy variable attributes
+                for name in source_variable.ncattrs():
+                    dest_variable.setncattr(name, source_variable.getncattr(name))
+
+                # Copy variable values
+                if (
+                        # we want to process this variable
+                        (not variables or name in variables)
+                        # it has a time dimension
+                        and time_dimension in source_variable.dimensions
+                        # and time indices are specified
+                        and time_indices
+                ):
+                    print('\tslicing')
+                    # copy only a subset of the time dimension
+                    slices = [slice(None),] * source_variable.ndim
+                    t = source_variable.dimensions.index(time_dimension)
+                    slices[t] = slice(time_indices[0], time_indices[1]+1)
+                    dest_variable[:] = source_variable[tuple(slices)]
+                else:
+                    dest_variable[:] = source_variable[:]
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser(
+        description='Copy a NetCDF file with some modifications, '
+                    'namely selecting a subset of the times for specified '
+                    'variables')
+    parser.add_argument(
+        'source', help='Source file to copy')
+    parser.add_argument(
+        'dest', help='Destination file')
+    parser.add_argument(
+        '--time-dimension', dest='time_dimension', default='time',
+        help='Time dimension name')
+    parser.add_argument(
+        '--time-indices', dest='time_indices', default=None,
+        help='Time indices')
+    parser.add_argument(
+        '--variables', default=None, help='Variables')
+    args = parser.parse_args()
+
+    nc_copy(
+        args.source, args.dest,
+        args.time_dimension,
+        args.time_indices and [int(i) for i in args.time_indices.split('-')],
+        args.variables and args.variables.split(',')
+    )

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
             data/tiny_gcm_climo_seasonal.nc
             data/tiny_gcm_climo_monthly.nc
             data/tiny_gridded_obs.nc
+            data/tiny_streamflow.nc
         '''.split()
     },
     include_package_data = True,

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         psycopg2
         numpy
         netCDF4
-        nchelpers>=5.3.0
+        nchelpers>=5.4.0,<6
         python-dateutil
         sqlparse
         PyCRS

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ setup(
         alembic
         psycopg2
         numpy
-        netCDF4
-        nchelpers>=5.4.0,<6
+        netCDF4==1.3
+        nchelpers>=5.5.0,<6
         python-dateutil
         sqlparse
         PyCRS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -342,12 +342,13 @@ def open_tiny_dataset(abbrev):
     return CFDataset(resource_filename('modelmeta', filename))
 
 
-# We parametrize this fixture so that every test that uses it is run for all
+# We parametrize these fixture so that every test that uses it is run for all
 # params. This can be overridden on specific tests by using
-# ``@pytest.mark.parametrize`` with arg ``indirect=['tiny_gridded_dataset']``;
+# ``@pytest.mark.parametrize`` with arg ``indirect=['<fixture name>']``;
 # see ``test_get_level_set_info`` for an example.
-# TODO: Parametrize over more tiny datasets.
-@pytest.fixture(params='''
+
+# TODO: Parametrize over more gridded datasets.
+gridded_dataset_names = '''
     gcm
     downscaled
     hydromodel_gcm
@@ -355,7 +356,17 @@ def open_tiny_dataset(abbrev):
     gcm_climo_seasonal
     gcm_climo_yearly
     gridded_obs
-'''.split())
+'''.split()
+
+# TODO: Parametrize over more dsg datasets.
+dsg_dataset_names = '''
+    streamflow
+'''.split()
+
+any_dataset_names = gridded_dataset_names + dsg_dataset_names
+
+
+@pytest.fixture(params=gridded_dataset_names)
 def tiny_gridded_dataset(request):
     """Return a 'tiny' test gridded dataset, based on request param.
     This fixture is used to parametrize over test data files.
@@ -367,13 +378,21 @@ def tiny_gridded_dataset(request):
     return open_tiny_dataset(request.param)
 
 
-# We parametrize this fixture so that every test that uses it is run for all
-# params. This can be overridden on specific tests by using
-# ``@pytest.mark.parametrize`` with arg ``indirect=['tiny_dsg_dataset']``;
-@pytest.fixture(params='''
-    streamflow
-'''.split())
+@pytest.fixture(params=dsg_dataset_names)
 def tiny_dsg_dataset(request):
+    """Return a 'tiny' test discrete sampling geometry dataset, based on
+    request param.
+    This fixture is used to parametrize over test data files.
+    This fixture must be invoked with indirection.
+
+    request.param: (str) selects the test file to be returned
+    returns: (nchelpers.CFDataset) test file as a CFDataset object
+    """
+    return open_tiny_dataset(request.param)
+
+
+@pytest.fixture(params=any_dataset_names)
+def tiny_any_dataset(request):
     """Return a 'tiny' test discrete sampling geometry dataset, based on
     request param.
     This fixture is used to parametrize over test data files.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -337,6 +337,11 @@ def db_uri(test_dsn):
 
 # Parametrized fixtures
 
+def open_tiny_dataset(abbrev):
+    filename = 'data/tiny_{}.nc'.format(abbrev)
+    return CFDataset(resource_filename('modelmeta', filename))
+
+
 # We parametrize this fixture so that every test that uses it is run for all
 # params. This can be overridden on specific tests by using
 # ``@pytest.mark.parametrize`` with arg ``indirect=['tiny_gridded_dataset']``;
@@ -352,15 +357,32 @@ def db_uri(test_dsn):
     gridded_obs
 '''.split())
 def tiny_gridded_dataset(request):
-    """Return a 'tiny' test dataset, based on request param.
+    """Return a 'tiny' test gridded dataset, based on request param.
     This fixture is used to parametrize over test data files.
     This fixture must be invoked with indirection.
 
     request.param: (str) selects the test file to be returned
     returns: (nchelpers.CFDataset) test file as a CFDataset object
     """
-    filename = 'data/tiny_{}.nc'.format(request.param)
-    return CFDataset(resource_filename('modelmeta', filename))
+    return open_tiny_dataset(request.param)
+
+
+# We parametrize this fixture so that every test that uses it is run for all
+# params. This can be overridden on specific tests by using
+# ``@pytest.mark.parametrize`` with arg ``indirect=['tiny_dsg_dataset']``;
+@pytest.fixture(params='''
+    streamflow
+'''.split())
+def tiny_dsg_dataset(request):
+    """Return a 'tiny' test discrete sampling geometry dataset, based on
+    request param.
+    This fixture is used to parametrize over test data files.
+    This fixture must be invoked with indirection.
+
+    request.param: (str) selects the test file to be returned
+    returns: (nchelpers.CFDataset) test file as a CFDataset object
+    """
+    return open_tiny_dataset(request.param)
 
 
 @pytest.fixture(params=[False, True])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -339,7 +339,7 @@ def db_uri(test_dsn):
 
 # We parametrize this fixture so that every test that uses it is run for all
 # params. This can be overridden on specific tests by using
-# ``@pytest.mark.parametrize`` with arg ``indirect=['tiny_dataset']``;
+# ``@pytest.mark.parametrize`` with arg ``indirect=['tiny_gridded_dataset']``;
 # see ``test_get_level_set_info`` for an example.
 # TODO: Parametrize over more tiny datasets.
 @pytest.fixture(params='''
@@ -351,7 +351,7 @@ def db_uri(test_dsn):
     gcm_climo_yearly
     gridded_obs
 '''.split())
-def tiny_dataset(request):
+def tiny_gridded_dataset(request):
     """Return a 'tiny' test dataset, based on request param.
     This fixture is used to parametrize over test data files.
     This fixture must be invoked with indirection.

--- a/tests/mm_cataloguer/test_associate_ensemble.py
+++ b/tests/mm_cataloguer/test_associate_ensemble.py
@@ -82,22 +82,22 @@ def test_find_ensemble__(test_session_with_ensembles, ensemble1):
 
 # associate_ensemble_to_data_file_variable
 
-@pytest.mark.parametrize('tiny_dataset, var_names', [
+@pytest.mark.parametrize('tiny_gridded_dataset, var_names', [
     ('gcm', {'tasmax'}),
     ('downscaled', {'tasmax'}),
     ('hydromodel_gcm', {'BASEFLOW', 'EVAP', 'GLAC_AREA_BAND', 'GLAC_MBAL_BAND', 'RUNOFF', 'SWE_BAND', }),
     ('gcm_climo_monthly', {'tasmax'}),
-], indirect=['tiny_dataset'])
+], indirect=['tiny_gridded_dataset'])
 def test_associate_ensemble_to_data_file_variable__(
         test_session_with_ensembles,
         ensemble1,
-        tiny_dataset,
+        tiny_gridded_dataset,
         var_names,
 ):
     session = test_session_with_ensembles
 
     # Set up test database
-    data_file = index_cf_file(session, tiny_dataset)
+    data_file = index_cf_file(session, tiny_gridded_dataset)
 
     # Extract some info
     assert set(
@@ -117,7 +117,7 @@ def test_associate_ensemble_to_data_file_variable__(
 
 # associate_ensemble_to_data_file
 
-@pytest.mark.parametrize('tiny_dataset, var_names, expected_var_names', [
+@pytest.mark.parametrize('tiny_gridded_dataset, var_names, expected_var_names', [
     ('gcm', None, {'tasmax'}),
     ('gcm', {'tasmax'}, {'tasmax'}),
     ('gcm', {'tasmax', 'foo'}, {'tasmax'}),
@@ -127,18 +127,18 @@ def test_associate_ensemble_to_data_file_variable__(
     ('hydromodel_gcm', None, {'BASEFLOW', 'EVAP', 'GLAC_AREA_BAND', 'GLAC_MBAL_BAND', 'RUNOFF', 'SWE_BAND', }),
     ('hydromodel_gcm', {'foo'}, set()),
     ('gcm_climo_monthly', None, {'tasmax'}),
-], indirect=['tiny_dataset'])
+], indirect=['tiny_gridded_dataset'])
 def test_associate_ensemble_to_data_file__(
         test_session_with_ensembles,
         ensemble1,
-        tiny_dataset,
+        tiny_gridded_dataset,
         var_names,
         expected_var_names
 ):
     session = test_session_with_ensembles
 
     # Set up test database
-    data_file = index_cf_file(session, tiny_dataset)
+    data_file = index_cf_file(session, tiny_gridded_dataset)
 
     # Associate
     associated_dfvs = associate_ensemble_to_data_file(
@@ -159,7 +159,7 @@ fp_hydromodel_gcm = resource_filename('modelmeta', 'data/tiny_hydromodel_gcm.nc'
 fp_gcm_climo_monthly = resource_filename('modelmeta', 'data/tiny_gcm_climo_monthly.nc')
 
 @pytest.mark.parametrize(
-    'tiny_dataset, regex_filepath, filepath, var_names, expected_filepaths, expected_var_names',
+    'tiny_gridded_dataset, regex_filepath, filepath, var_names, expected_filepaths, expected_var_names',
     [
         ('gcm', False, fp_gcm, None, {fp_gcm}, {'tasmax'}),
         ('gcm', True, fp_gcm, None, {fp_gcm}, {'tasmax'}),
@@ -178,12 +178,12 @@ fp_gcm_climo_monthly = resource_filename('modelmeta', 'data/tiny_gcm_climo_month
         ('hydromodel_gcm', False, fp_hydromodel_gcm, {'foo'}, {fp_hydromodel_gcm}, set()),
         ('gcm_climo_monthly', False, fp_gcm_climo_monthly, None, {fp_gcm_climo_monthly}, {'tasmax'}),
     ],
-    indirect=['tiny_dataset']
+    indirect=['tiny_gridded_dataset']
 )
 def test_associate_ensemble_to_filepath__(
         test_session_with_ensembles,
         ensemble1,
-        tiny_dataset,
+        tiny_gridded_dataset,
         regex_filepath,
         filepath,
         var_names,
@@ -193,7 +193,7 @@ def test_associate_ensemble_to_filepath__(
     session = test_session_with_ensembles
 
     # Set up test database
-    data_file = index_cf_file(session, tiny_dataset)
+    data_file = index_cf_file(session, tiny_gridded_dataset)
 
     # Associate
     associated_items = associate_ensemble_to_filepath(

--- a/tests/mm_cataloguer/test_index.py
+++ b/tests/mm_cataloguer/test_index.py
@@ -47,12 +47,14 @@ from mm_cataloguer.index_netcdf import \
     insert_run, find_run, find_or_insert_run, \
     insert_model, find_model, find_or_insert_model, \
     insert_emission, find_emission, find_or_insert_emission, \
-    insert_data_file_variable, find_data_file_variable, \
+    insert_data_file_variable_gridded, insert_data_file_variable_dsg_time_series, \
+    find_data_file_variable, \
     find_or_insert_data_file_variable, \
     insert_variable_alias, find_variable_alias, find_or_insert_variable_alias, \
     insert_level_set, find_level_set, find_or_insert_level_set, \
     insert_spatial_ref_sys, find_spatial_ref_sys, find_or_insert_spatial_ref_sys, \
     insert_grid, find_grid, find_or_insert_grid, \
+    insert_station, find_station, find_or_insert_station, find_or_insert_stations, \
     insert_timeset, find_timeset, find_or_insert_timeset, \
     get_grid_info, get_level_set_info, \
     seconds_since_epoch, usable_name, wkt
@@ -576,7 +578,7 @@ def test_find_or_insert_grid(test_session_with_empty_db, tiny_dataset, insert):
 
 # DataFileVariable
 
-def insert_data_file_variable_plus(
+def insert_data_file_variable_gridded_plus(
         test_session_with_empty_db, tiny_dataset, var_name, data_file):
     """Insert a ``DataFileVariable`` plus associated ``VariableAlias``,
     ``LevelSet``, and ``Grid`` objects.
@@ -588,24 +590,25 @@ def insert_data_file_variable_plus(
         test_session_with_empty_db, tiny_dataset, var_name)
     grid = insert_grid_plus_prime(
         test_session_with_empty_db, tiny_dataset, var_name)
-    data_file_variable = insert_data_file_variable(
+    data_file_variable = insert_data_file_variable_gridded(
         test_session_with_empty_db, tiny_dataset, var_name,
         data_file, variable_alias, level_set, grid
     )
     return data_file_variable
 
 
-cond_insert_data_file_variable_plus = \
-    conditional(insert_data_file_variable_plus)
+cond_insert_data_file_variable_gridded_plus = \
+    conditional(insert_data_file_variable_gridded_plus)
 
 
-def test_insert_data_file_variable(test_session_with_empty_db, tiny_dataset):
+def test_insert_data_file_variable_gridded(
+        test_session_with_empty_db, tiny_dataset):
     var_name = tiny_dataset.dependent_varnames()[0]
     variable = tiny_dataset.variables[var_name]
     range_min, range_max = tiny_dataset.var_range(var_name)
     data_file = insert_data_file(test_session_with_empty_db, tiny_dataset)
     dfv = check_insert(
-        insert_data_file_variable_plus,
+        insert_data_file_variable_gridded_plus,
         test_session_with_empty_db,
         tiny_dataset,
         var_name,
@@ -632,7 +635,7 @@ def test_find_data_file_variable(
     data_file = insert_data_file(test_session_with_empty_db, tiny_dataset)
     check_find(
         find_data_file_variable,
-        cond_insert_data_file_variable_plus,
+        cond_insert_data_file_variable_gridded_plus,
         test_session_with_empty_db,
         tiny_dataset,
         var_name,
@@ -647,7 +650,7 @@ def test_find_or_insert_data_file_variable(
     data_file = insert_data_file(test_session_with_empty_db, tiny_dataset)
     check_find_or_insert(
         find_or_insert_data_file_variable,
-        cond_insert_data_file_variable_plus,
+        cond_insert_data_file_variable_gridded_plus,
         test_session_with_empty_db,
         tiny_dataset,
         var_name,

--- a/tests/mm_cataloguer/test_index.py
+++ b/tests/mm_cataloguer/test_index.py
@@ -586,13 +586,10 @@ cond_insert_station = conditional(insert_station)
 
 def test_insert_station(test_session_with_empty_db, tiny_dsg_dataset):
     var_name = tiny_dsg_dataset.dependent_varnames()[0]
-    variable = tiny_dsg_dataset.variables[var_name]
-    # TODO: Move some of this to nchelpers
-    coordinates = [tiny_dsg_dataset.variables[name] for name in variable.coordinates.split()]
-    instance_dim = tiny_dsg_dataset.dimensions[coordinates[0].dimensions[0]]
-    name = next(c for c in coordinates if getattr(c, 'cf_role', None) == 'timeseries_id')
-    lat = next(c for c in coordinates if c.name in ['lat', 'latitude'])
-    lon = next(c for c in coordinates if c.name in ['lon', 'longitude'])
+    instance_dim = tiny_dsg_dataset.instance_dim(var_name)
+    name = tiny_dsg_dataset.id_instance_var(var_name)
+    lat = tiny_dsg_dataset.spatial_instance_var(var_name, 'X')
+    lon = tiny_dsg_dataset.spatial_instance_var(var_name, 'Y')
     i = 0
     assert instance_dim.size > 0
     check_insert(
@@ -610,13 +607,10 @@ def test_insert_station(test_session_with_empty_db, tiny_dsg_dataset):
 def test_find_station(test_session_with_empty_db, tiny_dsg_dataset, insert):
     assert tiny_dsg_dataset.sampling_geometry == 'dsg.timeSeries'
     var_name = tiny_dsg_dataset.dependent_varnames()[0]
-    variable = tiny_dsg_dataset.variables[var_name]
-    # TODO: Move some of this to nchelpers
-    coordinates = [tiny_dsg_dataset.variables[name] for name in variable.coordinates.split()]
-    instance_dim = tiny_dsg_dataset.dimensions[coordinates[0].dimensions[0]]
-    name = next(c for c in coordinates if getattr(c, 'cf_role', None) == 'timeseries_id')
-    lat = next(c for c in coordinates if c.name in ['lat', 'latitude'])
-    lon = next(c for c in coordinates if c.name in ['lon', 'longitude'])
+    instance_dim = tiny_dsg_dataset.instance_dim(var_name)
+    name = tiny_dsg_dataset.id_instance_var(var_name)
+    lat = tiny_dsg_dataset.spatial_instance_var(var_name, 'X')
+    lon = tiny_dsg_dataset.spatial_instance_var(var_name, 'Y')
     i = 0
     assert instance_dim.size > 0
     check_find(
@@ -631,13 +625,10 @@ def test_find_station(test_session_with_empty_db, tiny_dsg_dataset, insert):
 def test_find_or_insert_station(
         test_session_with_empty_db, tiny_dsg_dataset, insert):
     var_name = tiny_dsg_dataset.dependent_varnames()[0]
-    variable = tiny_dsg_dataset.variables[var_name]
-    # TODO: Move some of this to nchelpers
-    coordinates = [tiny_dsg_dataset.variables[name] for name in variable.coordinates.split()]
-    instance_dim = tiny_dsg_dataset.dimensions[coordinates[0].dimensions[0]]
-    name = next(c for c in coordinates if getattr(c, 'cf_role', None) == 'timeseries_id')
-    lat = next(c for c in coordinates if c.name in ['lat', 'latitude'])
-    lon = next(c for c in coordinates if c.name in ['lon', 'longitude'])
+    instance_dim = tiny_dsg_dataset.instance_dim(var_name)
+    name = tiny_dsg_dataset.id_instance_var(var_name)
+    lat = tiny_dsg_dataset.spatial_instance_var(var_name, 'X')
+    lon = tiny_dsg_dataset.spatial_instance_var(var_name, 'Y')
     i = 0
     assert instance_dim.size > 0
     check_find_or_insert(
@@ -655,13 +646,10 @@ def test_find_or_insert_stations(
     stations = find_or_insert_stations(
         test_session_with_empty_db, tiny_dsg_dataset, var_name)
 
-    variable = tiny_dsg_dataset.variables[var_name]
-    # TODO: Move some of this to nchelpers
-    coordinates = [tiny_dsg_dataset.variables[name] for name in variable.coordinates.split()]
-    instance_dim = tiny_dsg_dataset.dimensions[coordinates[0].dimensions[0]]
-    name = next(c for c in coordinates if getattr(c, 'cf_role', None) == 'timeseries_id')
-    lat = next(c for c in coordinates if c.name in ['lat', 'latitude'])
-    lon = next(c for c in coordinates if c.name in ['lon', 'longitude'])
+    instance_dim = tiny_dsg_dataset.instance_dim(var_name)
+    name = tiny_dsg_dataset.id_instance_var(var_name)
+    lat = tiny_dsg_dataset.spatial_instance_var(var_name, 'X')
+    lon = tiny_dsg_dataset.spatial_instance_var(var_name, 'Y')
     assert len(stations) == instance_dim.size
     for i, station in enumerate(stations):
         check_properties(
@@ -685,9 +673,7 @@ def test_associate_stations_to_data_file_variable_dsg_time_series(
     associations = associate_stations_to_data_file_variable_dsg_time_series(
         sesh, tiny_dsg_dataset, var_name, dfv_dsg_time_series_1
     )
-    # TODO: Move some of this to nchelpers
-    coordinates = [tiny_dsg_dataset.variables[name] for name in variable.coordinates.split()]
-    instance_dim = tiny_dsg_dataset.dimensions[coordinates[0].dimensions[0]]
+    instance_dim = tiny_dsg_dataset.instance_dim(var_name)
     assert instance_dim.size > 0
     assert len(associations) == instance_dim.size
 
@@ -770,10 +756,7 @@ def test_find_or_insert_data_file_variable_dsg(
         invoke=insert
     )
     stations = test_session_with_empty_db.query(Station).all()
-    # TODO: Move some of this to nchelpers
-    coordinates = [tiny_dsg_dataset.variables[name] for name in variable.coordinates.split()]
-    instance_dim = tiny_dsg_dataset.dimensions[coordinates[0].dimensions[0]]
-
+    instance_dim = tiny_dsg_dataset.instance_dim(var_name)
     assert len(stations) == instance_dim.size
     assert set(dfv.stations) == set(stations)
 

--- a/tests/mm_cataloguer/test_index.py
+++ b/tests/mm_cataloguer/test_index.py
@@ -901,34 +901,34 @@ cond_insert_data_file = conditional(insert_data_file)
 
 
 def test_insert_data_file(
-        monkeypatch, test_session_with_empty_db, tiny_gridded_dataset
+        monkeypatch, test_session_with_empty_db, tiny_any_dataset
 ):
     # Have to use a datetime with no hours, min, sec because apparently
     # SQLite loses precision
     fake_now = freeze_utcnow(monkeypatch, 2000, 1, 2)
-    dim_names = tiny_gridded_dataset.axes_dim()
+    dim_names = tiny_any_dataset.axes_dim()
     data_file = check_insert(
-        insert_data_file, test_session_with_empty_db, tiny_gridded_dataset,
-        filename=tiny_gridded_dataset.filepath(),
-        first_1mib_md5sum=tiny_gridded_dataset.first_MiB_md5sum,
-        unique_id=tiny_gridded_dataset.unique_id,
+        insert_data_file, test_session_with_empty_db, tiny_any_dataset,
+        filename=tiny_any_dataset.filepath(),
+        first_1mib_md5sum=tiny_any_dataset.first_MiB_md5sum,
+        unique_id=tiny_any_dataset.unique_id,
         index_time=fake_now,
         x_dim_name=dim_names.get('X', None),
         y_dim_name=dim_names.get('Y', None),
         z_dim_name=dim_names.get('Z', None),
         t_dim_name=dim_names.get('T', None)
     )
-    assert data_file.run == find_run(test_session_with_empty_db, tiny_gridded_dataset)
+    assert data_file.run == find_run(test_session_with_empty_db, tiny_any_dataset)
     assert data_file.timeset == \
-        find_timeset(test_session_with_empty_db, tiny_gridded_dataset)
+        find_timeset(test_session_with_empty_db, tiny_any_dataset)
 
 
-def test_find_data_file(test_session_with_empty_db, tiny_gridded_dataset, insert):
+def test_find_data_file(test_session_with_empty_db, tiny_any_dataset, insert):
     data_file = cond_insert_data_file(
-        test_session_with_empty_db, tiny_gridded_dataset, invoke=insert)
+        test_session_with_empty_db, tiny_any_dataset, invoke=insert)
     id_match, hash_match, filename_match = \
         find_data_file_by_id_hash_filename(
-            test_session_with_empty_db, tiny_gridded_dataset)
+            test_session_with_empty_db, tiny_any_dataset)
     if insert:
         assert id_match == data_file
         assert hash_match == data_file
@@ -939,12 +939,12 @@ def test_find_data_file(test_session_with_empty_db, tiny_gridded_dataset, insert
         assert not filename_match
 
 
-def test_delete_data_file(test_session_with_empty_db, tiny_gridded_dataset):
-    data_file = insert_data_file(test_session_with_empty_db, tiny_gridded_dataset)
+def test_delete_data_file(test_session_with_empty_db, tiny_any_dataset):
+    data_file = insert_data_file(test_session_with_empty_db, tiny_any_dataset)
     delete_data_file(test_session_with_empty_db, data_file)
     assert \
         find_data_file_by_id_hash_filename(
-            test_session_with_empty_db, tiny_gridded_dataset) \
+            test_session_with_empty_db, tiny_any_dataset) \
         == (None, None, None)
 
 
@@ -1067,7 +1067,7 @@ far_future = seconds_since_epoch(datetime.datetime(2100, 1, 1))
      False),
 ])
 def test_find_update_or_insert_cf_file__dup(
-        monkeypatch, test_session_with_empty_db, tiny_gridded_dataset,
+        monkeypatch, test_session_with_empty_db, tiny_any_dataset,
         dataset_mocks, os_path_mocks, same_data_file
 ):
     """Test cases where the data file to be inserted is a variant of an
@@ -1081,11 +1081,11 @@ def test_find_update_or_insert_cf_file__dup(
     on the dataset filename) should be changed for the test.
     """
     # Index original file
-    data_file1 = index_cf_file(test_session_with_empty_db, tiny_gridded_dataset)
+    data_file1 = index_cf_file(test_session_with_empty_db, tiny_any_dataset)
     assert data_file1
 
     # Mock specified differences into tiny_gridded_dataset
-    other_tiny_gridded_dataset = Mock(tiny_gridded_dataset, **dataset_mocks)
+    other_tiny_gridded_dataset = Mock(tiny_any_dataset, **dataset_mocks)
 
     # Mock specified differences into os.path
     for attr, value in os_path_mocks.items():
@@ -1186,6 +1186,7 @@ def test_index_netcdf_files(test_dsn_fs, test_engine_fs):
         'data/tiny_gcm_climo_monthly.nc',
         'data/tiny_gcm_climo_seasonal.nc',
         'data/tiny_gcm_climo_yearly.nc',
+        'data/tiny_streamflow.nc',
     ]
     filenames = [resource_filename('modelmeta', f) for f in test_files]
     data_file_ids = index_netcdf_files(filenames, test_dsn_fs)

--- a/tests/mm_cataloguer/test_index.py
+++ b/tests/mm_cataloguer/test_index.py
@@ -15,7 +15,7 @@ fixtures (which here delivers the test input file) To get around that, we use
 indirect fixtures, which are passed a parameter that they use to determine
 what tiny data file to return.
 
-The tiny_dataset fixture comes pre-parametrized, so every test that uses it
+The tiny_gridded_dataset fixture comes pre-parametrized, so every test that uses it
 is automatically run for every specified dataset. Only in special cases do we
 have to specify (override) that parametrization. See fixture definition for
 more details.
@@ -149,7 +149,7 @@ def freeze_utcnow(*args):
     return fake_now
 
 
-level_set_parametrization = ('tiny_dataset, var_name, level_axis_var_name', [
+level_set_parametrization = ('tiny_gridded_dataset, var_name, level_axis_var_name', [
     ('gcm', 'tasmax', None),
     ('downscaled', 'tasmax', None),
     ('hydromodel_gcm', 'SWE_BAND', 'depth'),
@@ -192,24 +192,24 @@ def test_spatial_ref_sys_orm(test_session_with_empty_db):
 
 # Test helper functions
 
-def test_get_grid_info(tiny_dataset):
-    info = get_grid_info(tiny_dataset, tiny_dataset.dependent_varnames()[0])
+def test_get_grid_info(tiny_gridded_dataset):
+    info = get_grid_info(tiny_gridded_dataset, tiny_gridded_dataset.dependent_varnames()[0])
     assert set(info.keys()) == \
         set('xc_var yc_var xc_values yc_values '
             'xc_grid_step yc_grid_step evenly_spaced_y'.split())
-    assert info['xc_var'] == tiny_dataset.variables['lon']
-    assert info['yc_var'] == tiny_dataset.variables['lat']
+    assert info['xc_var'] == tiny_gridded_dataset.variables['lon']
+    assert info['yc_var'] == tiny_gridded_dataset.variables['lat']
 
 
-# Note: Overriding default parametrization of tiny_dataset in these tests.
-@pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_dataset'])
-def test_get_level_set_info(tiny_dataset, var_name, level_axis_var_name):
-    info = get_level_set_info(tiny_dataset, var_name)
+# Note: Overriding default parametrization of tiny_gridded_dataset in these tests.
+@pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_gridded_dataset'])
+def test_get_level_set_info(tiny_gridded_dataset, var_name, level_axis_var_name):
+    info = get_level_set_info(tiny_gridded_dataset, var_name)
     if level_axis_var_name:
         assert set(info.keys()) == \
             set('level_axis_var vertical_levels'.split())
         assert info['level_axis_var'] == \
-            tiny_dataset.variables[level_axis_var_name]
+            tiny_gridded_dataset.variables[level_axis_var_name]
     else:
         assert info is None
 
@@ -219,31 +219,31 @@ def test_get_level_set_info(tiny_dataset, var_name, level_axis_var_name):
 cond_insert_model = conditional(insert_model)
 
 
-def test_insert_model(test_session_with_empty_db, tiny_dataset):
+def test_insert_model(test_session_with_empty_db, tiny_gridded_dataset):
     check_insert(
-        insert_model, test_session_with_empty_db, tiny_dataset,
-        short_name=tiny_dataset.metadata.model,
-        organization=tiny_dataset.metadata.institution,
-        type=tiny_dataset.model_type,
+        insert_model, test_session_with_empty_db, tiny_gridded_dataset,
+        short_name=tiny_gridded_dataset.metadata.model,
+        organization=tiny_gridded_dataset.metadata.institution,
+        type=tiny_gridded_dataset.model_type,
     )
 
 
-def test_find_model(test_session_with_empty_db, tiny_dataset, insert):
+def test_find_model(test_session_with_empty_db, tiny_gridded_dataset, insert):
     check_find(
         find_model,
         cond_insert_model,
         test_session_with_empty_db,
-        tiny_dataset,
+        tiny_gridded_dataset,
         invoke=insert
     )
 
 
-def test_find_or_insert_model(test_session_with_empty_db, tiny_dataset, insert):
+def test_find_or_insert_model(test_session_with_empty_db, tiny_gridded_dataset, insert):
     check_find_or_insert(
         find_or_insert_model,
         cond_insert_model,
         test_session_with_empty_db,
-        tiny_dataset,
+        tiny_gridded_dataset,
         invoke=insert
     )
 
@@ -253,45 +253,45 @@ def test_find_or_insert_model(test_session_with_empty_db, tiny_dataset, insert):
 cond_insert_emission = conditional(insert_emission)
 
 
-def test_insert_emission(test_session_with_empty_db, tiny_dataset):
+def test_insert_emission(test_session_with_empty_db, tiny_gridded_dataset):
     check_insert(
         insert_emission,
         test_session_with_empty_db,
-        tiny_dataset,
-        short_name=tiny_dataset.metadata.emissions
+        tiny_gridded_dataset,
+        short_name=tiny_gridded_dataset.metadata.emissions
     )
 
 
-def test_find_emission(test_session_with_empty_db, tiny_dataset, insert):
+def test_find_emission(test_session_with_empty_db, tiny_gridded_dataset, insert):
     check_find(
         find_emission,
         cond_insert_emission,
         test_session_with_empty_db,
-        tiny_dataset,
+        tiny_gridded_dataset,
         invoke=insert
     )
 
 
 def test_find_or_insert_emission(
-        test_session_with_empty_db, tiny_dataset, insert):
+        test_session_with_empty_db, tiny_gridded_dataset, insert):
     check_find_or_insert(
         find_or_insert_emission,
         cond_insert_emission,
         test_session_with_empty_db,
-        tiny_dataset,
+        tiny_gridded_dataset,
         invoke=insert
     )
 
 
 # Run
 
-def insert_run_plus(test_session_with_empty_db, tiny_dataset):
+def insert_run_plus(test_session_with_empty_db, tiny_gridded_dataset):
     """Insert a run plus associated emission and model objects.
     Return run, model, and emission inserted.
     """
-    emission = insert_emission(test_session_with_empty_db, tiny_dataset)
-    model = insert_model(test_session_with_empty_db, tiny_dataset)
-    run = insert_run(test_session_with_empty_db, tiny_dataset, model, emission)
+    emission = insert_emission(test_session_with_empty_db, tiny_gridded_dataset)
+    model = insert_model(test_session_with_empty_db, tiny_gridded_dataset)
+    run = insert_run(test_session_with_empty_db, tiny_gridded_dataset, model, emission)
     return run, model, emission
 
 
@@ -305,34 +305,34 @@ cond_insert_run_plus = conditional(insert_run_plus,
 cond_insert_run_plus_prime = conditional(insert_run_plus_prime)
 
 
-def test_insert_run(test_session_with_empty_db, tiny_dataset):
+def test_insert_run(test_session_with_empty_db, tiny_gridded_dataset):
     run, model, emission = \
-        insert_run_plus(test_session_with_empty_db, tiny_dataset)
+        insert_run_plus(test_session_with_empty_db, tiny_gridded_dataset)
     check_properties(
         run,
-        name=tiny_dataset.metadata.run,
-        project=tiny_dataset.metadata.project,
+        name=tiny_gridded_dataset.metadata.run,
+        project=tiny_gridded_dataset.metadata.project,
         model=model,
         emission=emission,
     )
 
 
-def test_find_run(test_session_with_empty_db, tiny_dataset, insert):
+def test_find_run(test_session_with_empty_db, tiny_gridded_dataset, insert):
     check_find(
         find_run,
         cond_insert_run_plus_prime,
         test_session_with_empty_db,
-        tiny_dataset,
+        tiny_gridded_dataset,
         invoke=insert
     )
 
 
-def test_find_or_insert_run(test_session_with_empty_db, tiny_dataset, insert):
+def test_find_or_insert_run(test_session_with_empty_db, tiny_gridded_dataset, insert):
     check_find_or_insert(
         find_or_insert_run,
         cond_insert_run_plus_prime,
         test_session_with_empty_db,
-        tiny_dataset,
+        tiny_gridded_dataset,
         invoke=insert
     )
 
@@ -342,13 +342,13 @@ def test_find_or_insert_run(test_session_with_empty_db, tiny_dataset, insert):
 cond_insert_variable_alias = conditional(insert_variable_alias)
 
 
-def test_insert_variable_alias(test_session_with_empty_db, tiny_dataset):
-    var_name = tiny_dataset.dependent_varnames()[0]
-    variable = tiny_dataset.variables[var_name]
+def test_insert_variable_alias(test_session_with_empty_db, tiny_gridded_dataset):
+    var_name = tiny_gridded_dataset.dependent_varnames()[0]
+    variable = tiny_gridded_dataset.variables[var_name]
     check_insert(
         insert_variable_alias,
         test_session_with_empty_db,
-        tiny_dataset,
+        tiny_gridded_dataset,
         var_name,
         long_name=variable.long_name,
         standard_name=usable_name(variable),
@@ -356,25 +356,25 @@ def test_insert_variable_alias(test_session_with_empty_db, tiny_dataset):
     )
 
 
-def test_find_variable_alias(test_session_with_empty_db, tiny_dataset, insert):
+def test_find_variable_alias(test_session_with_empty_db, tiny_gridded_dataset, insert):
     check_find(
         find_variable_alias,
         cond_insert_variable_alias,
         test_session_with_empty_db,
-        tiny_dataset,
-        tiny_dataset.dependent_varnames()[0],
+        tiny_gridded_dataset,
+        tiny_gridded_dataset.dependent_varnames()[0],
         invoke=insert
     )
 
 
 def test_find_or_insert_variable_alias(
-        test_session_with_empty_db, tiny_dataset, insert):
+        test_session_with_empty_db, tiny_gridded_dataset, insert):
     check_find_or_insert(
         find_or_insert_variable_alias,
         cond_insert_variable_alias,
         test_session_with_empty_db,
-        tiny_dataset,
-        tiny_dataset.dependent_varnames()[0],
+        tiny_gridded_dataset,
+        tiny_gridded_dataset.dependent_varnames()[0],
         invoke=insert
     )
 
@@ -384,21 +384,21 @@ def test_find_or_insert_variable_alias(
 cond_insert_level_set = conditional(insert_level_set)
 
 
-# Note: Overriding default parametrization of tiny_dataset in these tests.
+# Note: Overriding default parametrization of tiny_gridded_dataset in these tests.
 
-@pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_dataset'])
+@pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_gridded_dataset'])
 def test_insert_level_set(
-        test_session_with_empty_db, tiny_dataset,
+        test_session_with_empty_db, tiny_gridded_dataset,
         var_name, level_axis_var_name
 ):
-    variable = tiny_dataset.variables[var_name]
+    variable = tiny_gridded_dataset.variables[var_name]
     if level_axis_var_name:
-        level_axis_var = tiny_dataset.variables[level_axis_var_name]
+        level_axis_var = tiny_gridded_dataset.variables[level_axis_var_name]
         assert level_axis_var_name in variable.dimensions
         level_set = check_insert(
             insert_level_set,
             test_session_with_empty_db,
-            tiny_dataset, var_name,
+            tiny_gridded_dataset, var_name,
             level_units=level_axis_var.units
         )
         levels = (
@@ -413,34 +413,34 @@ def test_insert_level_set(
         check_insert(
             insert_level_set,
             test_session_with_empty_db,
-            tiny_dataset,
+            tiny_gridded_dataset,
             var_name
         )
 
 
-@pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_dataset'])
+@pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_gridded_dataset'])
 def test_find_level_set(
-        test_session_with_empty_db, tiny_dataset, var_name,
+        test_session_with_empty_db, tiny_gridded_dataset, var_name,
         level_axis_var_name, insert):
     check_find(
         find_level_set,
         cond_insert_level_set,
         test_session_with_empty_db,
-        tiny_dataset,
+        tiny_gridded_dataset,
         var_name,
         invoke=insert
     )
 
 
-@pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_dataset'])
+@pytest.mark.parametrize(*level_set_parametrization, indirect=['tiny_gridded_dataset'])
 def test_find_or_insert_level_set(
-        test_session_with_empty_db, tiny_dataset, var_name,
+        test_session_with_empty_db, tiny_gridded_dataset, var_name,
         level_axis_var_name, insert):
     check_find_or_insert(
         find_or_insert_level_set,
         cond_insert_level_set,
         test_session_with_empty_db,
-        tiny_dataset,
+        tiny_gridded_dataset,
         var_name,
         invoke=insert,
         expect_insert=bool(level_axis_var_name)
@@ -452,14 +452,14 @@ def test_find_or_insert_level_set(
 cond_insert_spatial_ref_sys = conditional(insert_spatial_ref_sys)
 
 
-def test_insert_spatial_ref_sys(test_session_with_empty_db, tiny_dataset):
+def test_insert_spatial_ref_sys(test_session_with_empty_db, tiny_gridded_dataset):
     sesh = test_session_with_empty_db
     q = sesh.query(func.max(SpatialRefSys.id).label('max_srid'))
     prev_max_srid = q.scalar()
 
-    var_name = tiny_dataset.dependent_varnames()[0]
+    var_name = tiny_gridded_dataset.dependent_varnames()[0]
     proj4_string = '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs'
-    srs = insert_spatial_ref_sys(sesh, tiny_dataset, var_name)
+    srs = insert_spatial_ref_sys(sesh, tiny_gridded_dataset, var_name)
 
     # Check that we did in fact insert a new SRS, and its id is according to
     # spec.
@@ -478,18 +478,18 @@ def test_insert_spatial_ref_sys(test_session_with_empty_db, tiny_dataset):
     sesh.close()
 
 
-def test_find_spatial_ref_sys(test_session_with_empty_db, tiny_dataset, insert):
+def test_find_spatial_ref_sys(test_session_with_empty_db, tiny_gridded_dataset, insert):
     check_find(
         find_spatial_ref_sys,
         cond_insert_spatial_ref_sys,
         test_session_with_empty_db,
-        tiny_dataset,
-        tiny_dataset.dependent_varnames()[0],
+        tiny_gridded_dataset,
+        tiny_gridded_dataset.dependent_varnames()[0],
         invoke=insert
     )
 
 def test_find_or_insert_spatial_ref_sys(
-        test_session_with_empty_db, tiny_dataset, insert):
+        test_session_with_empty_db, tiny_gridded_dataset, insert):
     sesh = test_session_with_empty_db
     q = sesh.query(func.max(SpatialRefSys.id).label('max_srid'))
     prev_max_srid = q.scalar()
@@ -498,8 +498,8 @@ def test_find_or_insert_spatial_ref_sys(
         find_or_insert_spatial_ref_sys,
         cond_insert_spatial_ref_sys,
         sesh,
-        tiny_dataset,
-        tiny_dataset.dependent_varnames()[0],
+        tiny_gridded_dataset,
+        tiny_gridded_dataset.dependent_varnames()[0],
         invoke=insert
     )
 
@@ -530,11 +530,11 @@ cond_insert_grid_plus = conditional(insert_grid_plus,
 cond_insert_grid_plus_prime = conditional(insert_grid_plus_prime)
 
 
-def test_insert_grid(test_session_with_empty_db, tiny_dataset):
-    var_name = tiny_dataset.dependent_varnames()[0]
-    info = get_grid_info(tiny_dataset, var_name)
+def test_insert_grid(test_session_with_empty_db, tiny_gridded_dataset):
+    var_name = tiny_gridded_dataset.dependent_varnames()[0]
+    info = get_grid_info(tiny_gridded_dataset, var_name)
     grid, srs = insert_grid_plus(
-        test_session_with_empty_db, tiny_dataset, var_name)
+        test_session_with_empty_db, tiny_gridded_dataset, var_name)
     check_properties(
         grid,
         xc_origin=info['xc_values'][0],
@@ -554,44 +554,52 @@ def test_insert_grid(test_session_with_empty_db, tiny_dataset):
         assert len(grid.y_cell_bounds) == len(info['yc_var'][:])
 
 
-def test_find_grid(test_session_with_empty_db, tiny_dataset, insert):
+def test_find_grid(test_session_with_empty_db, tiny_gridded_dataset, insert):
     check_find(
         find_grid,
         cond_insert_grid_plus_prime,
         test_session_with_empty_db,
-        tiny_dataset,
-        tiny_dataset.dependent_varnames()[0],
+        tiny_gridded_dataset,
+        tiny_gridded_dataset.dependent_varnames()[0],
         invoke=insert
     )
 
 
-def test_find_or_insert_grid(test_session_with_empty_db, tiny_dataset, insert):
+def test_find_or_insert_grid(test_session_with_empty_db, tiny_gridded_dataset, insert):
     check_find_or_insert(
         find_or_insert_grid,
         cond_insert_grid_plus_prime,
         test_session_with_empty_db,
-        tiny_dataset,
-        tiny_dataset.dependent_varnames()[0],
+        tiny_gridded_dataset,
+        tiny_gridded_dataset.dependent_varnames()[0],
         invoke=insert
     )
+
+
+# Station
+
+cond_insert_station = conditional(insert_station)
+
+def test_find_station():
+    pass
 
 
 # DataFileVariable
 
 def insert_data_file_variable_gridded_plus(
-        test_session_with_empty_db, tiny_dataset, var_name, data_file):
+        test_session_with_empty_db, tiny_gridded_dataset, var_name, data_file):
     """Insert a ``DataFileVariable`` plus associated ``VariableAlias``,
     ``LevelSet``, and ``Grid`` objects.
     Return ``DataFileVariable`` inserted.
     """
     variable_alias = insert_variable_alias(
-        test_session_with_empty_db, tiny_dataset, var_name)
+        test_session_with_empty_db, tiny_gridded_dataset, var_name)
     level_set = insert_level_set(
-        test_session_with_empty_db, tiny_dataset, var_name)
+        test_session_with_empty_db, tiny_gridded_dataset, var_name)
     grid = insert_grid_plus_prime(
-        test_session_with_empty_db, tiny_dataset, var_name)
+        test_session_with_empty_db, tiny_gridded_dataset, var_name)
     data_file_variable = insert_data_file_variable_gridded(
-        test_session_with_empty_db, tiny_dataset, var_name,
+        test_session_with_empty_db, tiny_gridded_dataset, var_name,
         data_file, variable_alias, level_set, grid
     )
     return data_file_variable
@@ -602,15 +610,15 @@ cond_insert_data_file_variable_gridded_plus = \
 
 
 def test_insert_data_file_variable_gridded(
-        test_session_with_empty_db, tiny_dataset):
-    var_name = tiny_dataset.dependent_varnames()[0]
-    variable = tiny_dataset.variables[var_name]
-    range_min, range_max = tiny_dataset.var_range(var_name)
-    data_file = insert_data_file(test_session_with_empty_db, tiny_dataset)
+        test_session_with_empty_db, tiny_gridded_dataset):
+    var_name = tiny_gridded_dataset.dependent_varnames()[0]
+    variable = tiny_gridded_dataset.variables[var_name]
+    range_min, range_max = tiny_gridded_dataset.var_range(var_name)
+    data_file = insert_data_file(test_session_with_empty_db, tiny_gridded_dataset)
     dfv = check_insert(
         insert_data_file_variable_gridded_plus,
         test_session_with_empty_db,
-        tiny_dataset,
+        tiny_gridded_dataset,
         var_name,
         data_file,
         file=data_file,
@@ -621,23 +629,23 @@ def test_insert_data_file_variable_gridded(
         disabled=False,
     )
     assert dfv.variable_alias == find_variable_alias(
-        test_session_with_empty_db, tiny_dataset, var_name)
+        test_session_with_empty_db, tiny_gridded_dataset, var_name)
     assert dfv.level_set == find_level_set(
-        test_session_with_empty_db, tiny_dataset, var_name)
+        test_session_with_empty_db, tiny_gridded_dataset, var_name)
     assert dfv.grid == find_grid(
-        test_session_with_empty_db, tiny_dataset, var_name)
+        test_session_with_empty_db, tiny_gridded_dataset, var_name)
 
 
 def test_find_data_file_variable(
-        test_session_with_empty_db, tiny_dataset, insert
+        test_session_with_empty_db, tiny_gridded_dataset, insert
 ):
-    var_name = tiny_dataset.dependent_varnames()[0]
-    data_file = insert_data_file(test_session_with_empty_db, tiny_dataset)
+    var_name = tiny_gridded_dataset.dependent_varnames()[0]
+    data_file = insert_data_file(test_session_with_empty_db, tiny_gridded_dataset)
     check_find(
         find_data_file_variable,
         cond_insert_data_file_variable_gridded_plus,
         test_session_with_empty_db,
-        tiny_dataset,
+        tiny_gridded_dataset,
         var_name,
         data_file,
         invoke=insert
@@ -645,14 +653,14 @@ def test_find_data_file_variable(
 
 
 def test_find_or_insert_data_file_variable(
-        test_session_with_empty_db, tiny_dataset, insert):
-    var_name = tiny_dataset.dependent_varnames()[0]
-    data_file = insert_data_file(test_session_with_empty_db, tiny_dataset)
+        test_session_with_empty_db, tiny_gridded_dataset, insert):
+    var_name = tiny_gridded_dataset.dependent_varnames()[0]
+    data_file = insert_data_file(test_session_with_empty_db, tiny_gridded_dataset)
     check_find_or_insert(
         find_or_insert_data_file_variable,
         cond_insert_data_file_variable_gridded_plus,
         test_session_with_empty_db,
-        tiny_dataset,
+        tiny_gridded_dataset,
         var_name,
         data_file,
         invoke=insert
@@ -664,22 +672,22 @@ def test_find_or_insert_data_file_variable(
 cond_insert_timeset = conditional(insert_timeset)
 
 
-def test_insert_timeset(test_session_with_empty_db, tiny_dataset):
+def test_insert_timeset(test_session_with_empty_db, tiny_gridded_dataset):
     timeset = check_insert(
-        insert_timeset, test_session_with_empty_db, tiny_dataset,
-        calendar=tiny_dataset.time_var.calendar,
-        multi_year_mean=tiny_dataset.is_multi_year_mean,
-        num_times=tiny_dataset.time_var.size,
-        time_resolution=tiny_dataset.time_resolution,
+        insert_timeset, test_session_with_empty_db, tiny_gridded_dataset,
+        calendar=tiny_gridded_dataset.time_var.calendar,
+        multi_year_mean=tiny_gridded_dataset.is_multi_year_mean,
+        num_times=tiny_gridded_dataset.time_var.size,
+        time_resolution=tiny_gridded_dataset.time_resolution,
     )
-    assert len(timeset.times) == len(tiny_dataset.time_var[:])
-    if tiny_dataset.is_multi_year_mean:
+    assert len(timeset.times) == len(tiny_gridded_dataset.time_var[:])
+    if tiny_gridded_dataset.is_multi_year_mean:
         climatology_bounds = (
-            tiny_dataset.variables[tiny_dataset.climatology_bounds_var_name]
+            tiny_gridded_dataset.variables[tiny_gridded_dataset.climatology_bounds_var_name]
             [:, :]
         )
-        units = tiny_dataset.time_var.units
-        calendar = tiny_dataset.time_var.calendar
+        units = tiny_gridded_dataset.time_var.units
+        calendar = tiny_gridded_dataset.time_var.calendar
         time_starts = [date2num(ct.time_start, units, calendar)
                        for ct in timeset.climatological_times]
         time_ends = [date2num(ct.time_end, units, calendar)
@@ -687,8 +695,8 @@ def test_insert_timeset(test_session_with_empty_db, tiny_dataset):
         assert time_starts == [cb[0] for cb in climatology_bounds]
         assert time_ends == [cb[1] for cb in climatology_bounds]
         assert timeset.start_date, timeset.end_date == \
-            to_datetime(num2date(tiny_dataset.nominal_time_span))
-        if tiny_dataset.time_resolution == 'seasonal':
+            to_datetime(num2date(tiny_gridded_dataset.nominal_time_span))
+        if tiny_gridded_dataset.time_resolution == 'seasonal':
             def wrap(month):
                 return (month - 1) % 12 + 1
             assert timeset.start_date.month == \
@@ -705,27 +713,27 @@ def test_insert_timeset(test_session_with_empty_db, tiny_dataset):
     else:
         assert len(timeset.climatological_times) == 0
         assert timeset.start_date, timeset.end_date == \
-            to_datetime(tiny_dataset.time_range_as_dates)
+            to_datetime(tiny_gridded_dataset.time_range_as_dates)
 
 
-def test_find_timeset(test_session_with_empty_db, tiny_dataset, insert):
+def test_find_timeset(test_session_with_empty_db, tiny_gridded_dataset, insert):
     check_find(
         find_timeset,
         cond_insert_timeset,
         test_session_with_empty_db,
-        tiny_dataset,
+        tiny_gridded_dataset,
         invoke=insert
     )
 
 
 def test_find_or_insert_timeset(
-        test_session_with_empty_db, tiny_dataset, insert
+        test_session_with_empty_db, tiny_gridded_dataset, insert
 ):
     check_find_or_insert(
         find_or_insert_timeset,
         cond_insert_timeset,
         test_session_with_empty_db,
-        tiny_dataset,
+        tiny_gridded_dataset,
         invoke=insert
     )
 
@@ -736,34 +744,34 @@ cond_insert_data_file = conditional(insert_data_file)
 
 
 def test_insert_data_file(
-        monkeypatch, test_session_with_empty_db, tiny_dataset
+        monkeypatch, test_session_with_empty_db, tiny_gridded_dataset
 ):
     # Have to use a datetime with no hours, min, sec because apparently
     # SQLite loses precision
     fake_now = freeze_utcnow(monkeypatch, 2000, 1, 2)
-    dim_names = tiny_dataset.axes_dim()
+    dim_names = tiny_gridded_dataset.axes_dim()
     data_file = check_insert(
-        insert_data_file, test_session_with_empty_db, tiny_dataset,
-        filename=tiny_dataset.filepath(),
-        first_1mib_md5sum=tiny_dataset.first_MiB_md5sum,
-        unique_id=tiny_dataset.unique_id,
+        insert_data_file, test_session_with_empty_db, tiny_gridded_dataset,
+        filename=tiny_gridded_dataset.filepath(),
+        first_1mib_md5sum=tiny_gridded_dataset.first_MiB_md5sum,
+        unique_id=tiny_gridded_dataset.unique_id,
         index_time=fake_now,
         x_dim_name=dim_names.get('X', None),
         y_dim_name=dim_names.get('Y', None),
         z_dim_name=dim_names.get('Z', None),
         t_dim_name=dim_names.get('T', None)
     )
-    assert data_file.run == find_run(test_session_with_empty_db, tiny_dataset)
+    assert data_file.run == find_run(test_session_with_empty_db, tiny_gridded_dataset)
     assert data_file.timeset == \
-        find_timeset(test_session_with_empty_db, tiny_dataset)
+        find_timeset(test_session_with_empty_db, tiny_gridded_dataset)
 
 
-def test_find_data_file(test_session_with_empty_db, tiny_dataset, insert):
+def test_find_data_file(test_session_with_empty_db, tiny_gridded_dataset, insert):
     data_file = cond_insert_data_file(
-        test_session_with_empty_db, tiny_dataset, invoke=insert)
+        test_session_with_empty_db, tiny_gridded_dataset, invoke=insert)
     id_match, hash_match, filename_match = \
         find_data_file_by_id_hash_filename(
-            test_session_with_empty_db, tiny_dataset)
+            test_session_with_empty_db, tiny_gridded_dataset)
     if insert:
         assert id_match == data_file
         assert hash_match == data_file
@@ -774,12 +782,12 @@ def test_find_data_file(test_session_with_empty_db, tiny_dataset, insert):
         assert not filename_match
 
 
-def test_delete_data_file(test_session_with_empty_db, tiny_dataset):
-    data_file = insert_data_file(test_session_with_empty_db, tiny_dataset)
+def test_delete_data_file(test_session_with_empty_db, tiny_gridded_dataset):
+    data_file = insert_data_file(test_session_with_empty_db, tiny_gridded_dataset)
     delete_data_file(test_session_with_empty_db, data_file)
     assert \
         find_data_file_by_id_hash_filename(
-            test_session_with_empty_db, tiny_dataset) \
+            test_session_with_empty_db, tiny_gridded_dataset) \
         == (None, None, None)
 
 
@@ -902,7 +910,7 @@ far_future = seconds_since_epoch(datetime.datetime(2100, 1, 1))
      False),
 ])
 def test_find_update_or_insert_cf_file__dup(
-        monkeypatch, test_session_with_empty_db, tiny_dataset,
+        monkeypatch, test_session_with_empty_db, tiny_gridded_dataset,
         dataset_mocks, os_path_mocks, same_data_file
 ):
     """Test cases where the data file to be inserted is a variant of an
@@ -916,11 +924,11 @@ def test_find_update_or_insert_cf_file__dup(
     on the dataset filename) should be changed for the test.
     """
     # Index original file
-    data_file1 = index_cf_file(test_session_with_empty_db, tiny_dataset)
+    data_file1 = index_cf_file(test_session_with_empty_db, tiny_gridded_dataset)
     assert data_file1
 
-    # Mock specified differences into tiny_dataset
-    other_tiny_dataset = Mock(tiny_dataset, **dataset_mocks)
+    # Mock specified differences into tiny_gridded_dataset
+    other_tiny_gridded_dataset = Mock(tiny_gridded_dataset, **dataset_mocks)
 
     # Mock specified differences into os.path
     for attr, value in os_path_mocks.items():
@@ -928,7 +936,7 @@ def test_find_update_or_insert_cf_file__dup(
 
     # Index mocked duplicate file
     data_file2 = find_update_or_insert_cf_file(
-        test_session_with_empty_db, other_tiny_dataset)
+        test_session_with_empty_db, other_tiny_gridded_dataset)
 
     # Set up checks for second indexing
     def mock_value(key):


### PR DESCRIPTION
Resolves #63 

Updates `index_netcdf` to index DSG datasets, namely streamflow datasets (only current test).

Also adds a utility script (`scripts/nc-copy-modify.py`) for copying a time slice of a NetCDF dataset. CDO consistently messes up datasets by renaming variables, dropping variables, altering attributes (on variables; in particular, `var:coordinates`, argh), and dropping attributes. Enough! It is time to fight back with our own script.

The utility function can and perhaps should be pulled out into a different PR or even repo. It's in one commit so that will be easy.

To do:

- [x] Fix deletion problem for DSG datasets
- [x] Test on more DSG datasets
- [x] Factor out common code for identifying DSG x/lon, y/lat, id variables, etc. into `nchelpers`.