### PR TITLE
Squash a couple minor bugs

### DIFF
--- a/alembic/versions/12f290b63791_handle_variant_sampling_geometries.py
+++ b/alembic/versions/12f290b63791_handle_variant_sampling_geometries.py
@@ -90,7 +90,7 @@ def upgrade():
     sa.ForeignKeyConstraint(
         ['data_file_variable_dsg_ts_id'],
         ['data_file_variables_dsg_time_series.data_file_variable_dsg_ts_id'],
-        name='data_file_variables_dsg_time_series_x_stations_data_file_variable_dsg_ts_id_id_fkey',
+        name='dfv_dsg_time_series_x_stations_dfv_dsg_ts_id_id_fkey',
         ondelete='CASCADE'),
     sa.ForeignKeyConstraint(
         ['station_id'], ['stations.station_id'],

--- a/modelmeta/v2.py
+++ b/modelmeta/v2.py
@@ -221,7 +221,7 @@ class DataFileVariableDSGTimeSeriesXStation(Base):
         Integer, 
         ForeignKey(
             'data_file_variables_dsg_time_series.data_file_variable_dsg_ts_id',
-            name='data_file_variables_dsg_time_series_x_stations_data_file_variable_dsg_ts_id_id_fkey',
+            name='dfv_dsg_time_series_x_stations_dfv_dsg_ts_id_id_fkey',
             ondelete='CASCADE'),
         primary_key=True,
         nullable=False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
 
 def make_data_file(i, run=None, timeset=None):
     return DataFile(
+        id=i,
         filename='data_file_{}'.format(i),
         first_1mib_md5sum='first_1mib_md5sum',
         unique_id='unique_id_{}'.format(i),
@@ -169,6 +170,7 @@ def dfv_gridded_1(data_file_1, variable_alias_1, level_set_1, grid_1):
 
 def make_test_dfv_dsg_time_series(i, file=None, variable_alias=None):
     return DataFileVariableDSGTimeSeries(
+        id=i,
         derivation_method='derivation_method_{}'.format(i),
         variable_cell_methods='variable_cell_methods_{}'.format(i),
         netcdf_variable_name='var_{}'.format(i),


### PR DESCRIPTION
This PR squashes a couple of minor bugs that have cropped up. One where
an identifier is longer than PG's default max_identifier_length and another
where a warning in version of SQLAlchemy 1.2 became an error in version 1.3 
Fixes #80 Fixes #84 