### PR TITLE
Index time-invariant datasets

### DIFF
--- a/mm_cataloguer/index_netcdf.py
+++ b/mm_cataloguer/index_netcdf.py
@@ -1067,13 +1067,13 @@ def find_or_insert_timeset(sesh, cf):
     :param cf: CFDatafile object representing NetCDF file
     :return: existing or new ``TimeSet`` record, or None
     """
-    if not cf.is_time_invariant:
-        time_set = find_timeset(sesh, cf)
-        if time_set:
-            return time_set
-        return insert_timeset(sesh, cf)
-    else:
+    if cf.is_time_invariant:
         return None
+
+    time_set = find_timeset(sesh, cf)
+    if time_set:
+        return time_set
+    return insert_timeset(sesh, cf)
 
 
 # DataFile

--- a/mm_cataloguer/index_netcdf.py
+++ b/mm_cataloguer/index_netcdf.py
@@ -1060,15 +1060,20 @@ def insert_timeset(sesh, cf):
 def find_or_insert_timeset(sesh, cf):
     """Find existing or insert new ``TimeSet`` record (and associated `
     `Time`` and ``ClimatologicalTime`` records) corresponding to a NetCDF file.
+    If this is a time-invariant dataset (has no time dimension at all, like
+    elevation or soil type data), return None.
 
     :param sesh: modelmeta database session
     :param cf: CFDatafile object representing NetCDF file
-    :return: existing or new ``TimeSet`` record
+    :return: existing or new ``TimeSet`` record, or None
     """
-    time_set = find_timeset(sesh, cf)
-    if time_set:
-        return time_set
-    return insert_timeset(sesh, cf)
+    if not cf.is_time_invariant:
+        time_set = find_timeset(sesh, cf)
+        if time_set:
+            return time_set
+        return insert_timeset(sesh, cf)
+    else:
+        return None
 
 
 # DataFile
@@ -1107,7 +1112,7 @@ def insert_data_file(sesh, cf):  # create.data.file.id
     logger.info("Creating new DataFile for unique_id {}".format(cf.unique_id))
     # TODO: Parametrize on timeset, run; like run on model, emission
     timeset = find_or_insert_timeset(sesh, cf)
-    assert timeset
+    assert timeset or cf.is_time_invariant
     run = find_or_insert_run(sesh, cf)
     assert run
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ alembic
 psycopg2
 numpy
 netCDF4==1.3
-nchelpers>=5.5.0,<6
+nchelpers>=5.5.3,<6
 python-dateutil
 sqlparse
 git+git://github.com/karimbahgat/PyCRS.git@70e4210b16260b2c17fd31947816836a29a12117


### PR DESCRIPTION
This PR changes `index_netcdf` to support indexing time-invariant netCDF files. These datasets contain information that doesn't generally change over time, like elevation or soil type. Datasets without a time dimension simply omit the TimeSet attribute when indexing.

Nchelpers is updated to version 5.5.3, which adds the `is_time_invariant` attribute to `CFDataset` and handles generating `unique_id`s for time-invariant datatsets.