### PR TITLE
Jenkins support

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,0 +1,76 @@
+# -- DISCLAIMER --
+# This Dockerfile is used by Jenkins to create a testing environment.  It will
+# NOT create a containerized instance of modelmeta.
+FROM ubuntu:18.04
+
+# Set version for the build stage
+ARG PYTHON_MAJOR=3.6
+ARG PYTHON_PATCH=10
+
+# Set up locales
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+	apt-get install -y locales && \
+	sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+	dpkg-reconfigure --frontend=noninteractive locales && \
+	update-locale LANG=en_US.UTF-8
+ENV LANG en_US.UTF-8
+
+# Set up a repo
+RUN apt-get install -y wget \
+	gnupg && \
+	wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
+	apt-key add && \
+	sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" >> /etc/apt/sources.list.d/postgresql.list' && \
+	apt-get -y update
+
+# Install modelmeta requirements
+RUN apt-get install -y git \
+	libhdf5-serial-dev \
+	libnetcdf-dev \
+	libspatialite-dev \
+	postgresql-9.4-postgis-2.4 \
+	postgresql-server-dev-9.4
+
+# Install common packages for python source installation
+RUN apt-get install -y libncursesw5-dev \
+	libgdbm-dev
+
+# Determine which set of requirements are needed for python 3.6/7
+RUN if [ "${PYTHON_MAJOR}" = "3.6" ]; \
+	then \
+		# 3.6
+		apt-get install -y libreadline-gplv2-dev \
+			libssl-dev \
+			libsqlite3-dev \
+			tk-dev \
+			libc6-dev \
+			libbz2-dev; \
+	else \
+		# 3.7
+		apt-get install -y build-essential \
+			zlib1g-dev \
+			libnss3-dev \
+			libssl-dev \
+			libreadline-dev \
+			libffi-dev; \
+	fi
+
+# Download and install Python
+RUN wget https://www.python.org/ftp/python/${PYTHON_MAJOR}.${PYTHON_PATCH}/Python-${PYTHON_MAJOR}.${PYTHON_PATCH}.tgz && \
+	tar -xvf Python-${PYTHON_MAJOR}.${PYTHON_PATCH}.tgz && \
+	cd Python-${PYTHON_MAJOR}.${PYTHON_PATCH} && \
+	./configure && \
+	make && \
+	make install
+
+# Create custom user
+RUN useradd -ms /bin/bash -u 1000 tester
+
+# Setup some directories for python installations
+RUN mkdir -p /usr/local/lib/python${PYTHON_MAJOR}/ && \
+	chown -R tester /usr/local/lib/python${PYTHON_MAJOR} && \
+	chown -R tester /usr/local/bin/
+
+# Use custom user
+USER tester

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,0 +1,34 @@
+@Library('pcic-pipeline-library')_
+
+
+node {
+    stage('Code Collection') {
+        collectCode()
+    }
+
+    stage('Testing') {
+        def requirements = ['requirements.txt', 'test_requirements.txt']
+        def pytestArgs = '-v'
+        def options =  [containerData: 'crmprtd']
+
+        parallel "Python 3.6": {
+            runPythonTestSuite('pcic/modelmeta-test-env:python-3.6',
+                               requirements, pytestArgs, options)
+        },
+        "Python 3.7": {
+            runPythonTestSuite('pcic/modelmeta-test-env:python-3.7',
+                               requirements, pytestArgs, options)
+        }
+    }
+
+    if (isPypiPublishable()) {
+        stage('Push to PYPI') {
+            publishPythonPackage('pcic/modelmeta-test-env:python-3.6',
+                                 'PCIC_PYPI_CREDS')
+        }
+    }
+
+    stage('Clean Workspace') {
+        cleanWs()
+    }
+}


### PR DESCRIPTION
This PR introduces Jenkins support for `modelmeta`.  A `Jenkinsfile` has been added that controls the Jenkins pipeline. The pipeline will run the test suite in `python3.6` and `python3.7` (in parallel) and push packages to `pypi` when conditions are met (new git tags on `master`).  The `Dockerfile` is responsible for creating an environment where the test suite can be run.  The file itself does not build or set up `modelmeta` that is handled by the pipeline.  As a note, the maintaining of the image created by the `Dockerfile` will be done by a separate pipeline.