### PR TITLE
Allow GetFeatureInfo requests

### DIFF
--- a/ncwms_configurator/ncwms_configurator.py
+++ b/ncwms_configurator/ncwms_configurator.py
@@ -13,19 +13,19 @@ from lxml import etree
 log = logging.getLogger(__name__)
 
 DEFAULT_CONTACT_CHILDREN = {
-    "name": "",
-    "organization": "",
+    "name": "Pacific Climate Impacts Consortium",
+    "organization": "Pacific Climate Impacts Consortium",
     "telephone": "",
     "email": ""
 }
 
 DEFAULT_SERVER_CHILDREN = {
-    "title": "My ncWMS server",
+    "title": "PCIC ncWMS server",
     "allowFeatureInfo": "True",
     "maxImageWidth": "1024",
     "maxImageHeight": "1024",
     "abstract": "",
-    "keywords": "",
+    "keywords": "Climate, CMIP5, BCCAQ, Climdex",
     "url": "",
     "allowglobalcapabilities": "true"
 }
@@ -84,6 +84,8 @@ def get_element(element_name, atts={}, **kwargs):
         children = DEFAULT_SERVER_CHILDREN
         if(args.version == 1):
             children["adminPassword"] = "ncWMS"
+        else:
+            children["allowFeatureInfo"] = "true"
 
     elif element_name == "cache":
         if(args.version == 2):


### PR DESCRIPTION
This PR adds the `allowFeatureInfo` tag to the configuration file used to setup an ncWMS server. This tells ncWMS to accept `GetFeatureInfo` requests, which return numerical data on the area inside a specified polygon. We haven't needed these in the past, but plan2adapt uses them.

It also adds some very basic metadata on the ncWMS web interface, like changing it to say "PCIC ncWMS server" instead of "My ncWMS server". Since we now have outside parties building maps from our servers into their applications, it seemed like a good idea to be slightly more informative.

Resolves #93 
Resolves #87 